### PR TITLE
feat: implement TTL index (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can add indexes to fields using the `#[index(...)]` attribute.
 - `name = "...""`: Custom name for the index.
 - `background`: Builds index in the background without locking the database.
 - `order = 1 | -1`: Index sort order (1 = ascending, -1 = descending).
+- `expire_after_secs = ...`: Time-to-live for the index in seconds.
 
 ---
 

--- a/oximod/tests/index.rs
+++ b/oximod/tests/index.rs
@@ -1,7 +1,8 @@
-use mongodb::bson::{DateTime, oid::ObjectId};
+use mongodb::bson::{DateTime, oid::ObjectId, doc};
 use oximod::{set_global_client, Model};
 use testresult::TestResult;
 use serde::{Deserialize, Serialize};
+use std::{thread::sleep, time::Duration};
 
 // Run test: cargo nextest run creates_indexes_correctly
 #[tokio::test] // Might throw `expected Expr rust-analyzer` so disable "macro-error"
@@ -44,4 +45,41 @@ async fn creates_indexes_correctly() -> TestResult {
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());
     Ok(()) 
+}
+
+// Run test: cargo nextest run ttl_index_removes_expired_documents
+#[tokio::test]
+async fn ttl_index_removes_expired_documents() -> TestResult {
+    dotenv::dotenv().ok();
+    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
+    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+
+    #[derive(Model, Serialize, Deserialize)]
+    #[db("test")]
+    #[collection("ttl_test")]
+    pub struct Session {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[index(expire_after_secs = 2)]
+        created_at: Option<DateTime>,
+    }
+
+    Session::clear().await?;
+
+    // Insert a document with a created_at timestamp in the past
+    let expired_session = Session {
+        _id: None,
+        created_at: Some(DateTime::from_millis(DateTime::now().timestamp_millis() - 10_000)),
+    };
+
+    expired_session.save().await?;
+
+    // Give MongoDB TTL monitor enough time to delete the expired document
+    sleep(Duration::from_secs(65));
+
+    let remaining = Session::find(doc! {}).await?;
+    assert_eq!(remaining.len(), 0, "Expected document to be expired and deleted");
+
+    Ok(())
 }

--- a/oximod/tests/index.rs
+++ b/oximod/tests/index.rs
@@ -1,4 +1,4 @@
-use mongodb::bson::oid::ObjectId;
+use mongodb::bson::{DateTime, oid::ObjectId};
 use oximod::{set_global_client, Model};
 use testresult::TestResult;
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,9 @@ async fn creates_indexes_correctly() -> TestResult {
         #[index(sparse, order = "-1")]
         age: Option<i32>,
 
+        #[index(expire_after_secs = 3600)]
+        created_at: Option<DateTime>,
+
         active: bool,
     }
 
@@ -33,6 +36,7 @@ async fn creates_indexes_correctly() -> TestResult {
         _id: None,
         name: "IndexUser".to_string(),
         age: Some(25),
+        created_at: Some(DateTime::now()),
         active: true,
     };
 


### PR DESCRIPTION
This PR finalizes the TTL index implementation for `#[index(expire_after_secs = ...)]`.

- Based on initial work by @tyrantlink in #3
- Confirmed behavior through a full integration test with document expiry

Closes #2
Supersedes #3

Co-authored-by: tyrantlink <38902185+tyrantlink@users.noreply.github.com>