### PR TITLE
feat: add default, new, and fluent api builders (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ OxiMod is a schema-based Object-Document Mapper (ODM) for MongoDB, designed for 
 
 Inspired by Mongoose, OxiMod brings a structured modeling experience while embracing Rust's type safety and performance. It works with any async runtime and is currently tested using `tokio`.
 
+### 🚀 New in `v0.1.7` – Fluent API Builders
+
+OxiMod now supports **fluent API builders** and a `new()` method for ergonomic model creation:
+
+```rust
+let user = User::new()
+    .name("Alice".to_string())
+    .age(30)
+    .active(true);
+```
+
+- Supports `Option<T>` and non-optional fields.
+- Works with `#[default("...")]` for seamless defaults.
+- Customize `_id` setter via `#[document_id_setter_ident("...")]`.
+
+Use `user.save().await?` just like before!
+
 ---
 
 ## Features
@@ -32,6 +49,12 @@ Inspired by Mongoose, OxiMod brings a structured modeling experience while embra
 - **Validation Support**  
   Add field-level validation using `#[validate(...)]`. Supports length, email, pattern, positivity, and more.
 
+- **Default Values**  
+  Use `#[default(...)]` to specify field defaults for strings, numbers, and enums.
+
+- **Builder API & `new()` Support**  
+  Use `Model::default()` or `Model::new()` to initialize structs and chain fluent setters. Customize `_id` setter name with `#[document_id_setter_ident(...)]`.
+
 - **Clear Error Handling**  
   Strongly typed, developer-friendly errors based on `thiserror`.
 
@@ -45,6 +68,7 @@ OxiMod supports attributes at both the struct level and field level.
 
 - `#[db("name")]`: Specifies the MongoDB database the model belongs to.
 - `#[collection("name")]`: Specifies the collection name within the database.
+- `#[document_id_setter_ident("name")]`: Optional. Renames the `_id` builder function for fluent `.new()`/`.default()` APIs.
 
 ### Field-Level Index Attributes
 
@@ -79,11 +103,17 @@ You can apply validations on fields using the `#[validate(...)]` attribute.
 
 > 💡 Use native Rust enums instead of `enum_values`.
 
+### Field-Level Default Attributes
+
+- `#[default("value")]`: Assigns a default value for strings.
+- `#[default(42)]`: Sets default for numbers.
+- `#[default(MyEnum::Variant)]`: Sets default for enums.
+
+Accessible via `Model::new()` or `Model::default()`.
+
 ---
 
 ## Example
-
-This example demonstrates how to define a model with schema-level and field-level metadata.
 
 ```rust
 use oximod::{set_global_client, Model};
@@ -109,16 +139,19 @@ struct User {
     #[validate(non_negative)]
     age: i32,
 
+    #[default(false)]
     active: bool,
 }
 ```
 
 In this example:
+
 - `#[db("my_app_db")]` and `#[collection("users")]` configure the database and collection.
 - The `email` field has a descending, unique index with a custom name.
 - The `phone` field is indexed only when it exists in the document (sparse).
 - The `name` field must be at least 3 characters long.
 - The `age` field must be non-negative.
+- The `active` field defaults to `false`.
 
 ---
 
@@ -134,6 +167,7 @@ cargo run --example query
 cargo run --example update
 cargo run --example delete
 cargo run --example by_id
+cargo run --example default_usage
 ```
 
 Each file clears previous data on run and demonstrates isolated functionality.

--- a/oximod/Cargo.toml
+++ b/oximod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oximod"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Arshia Eskandari <email@arshiaeskandari.com>"]
 description = "MongoDB ODM for Rust inspired by Mongoose"
@@ -14,8 +14,8 @@ categories = ["database", "asynchronous"]
 async-trait = "0.1.86"
 mongodb = "3.2.1"
 thiserror = "2.0.11"
-oximod_core = { version = "0.1.6", path = "../oximod_core" }
-oximod_macros = { version = "0.1.7", path = "../oximod_macros" }
+oximod_core = { version = "0.1.7", path = "../oximod_core" }
+oximod_macros = { version = "0.1.8", path = "../oximod_macros" }
 serde = "1.0.219"
 futures-util = "0.3.31"
 regex = "1.11.1"

--- a/oximod/README.md
+++ b/oximod/README.md
@@ -10,6 +10,24 @@ OxiMod is a schema-based Object-Document Mapper (ODM) for MongoDB, designed for 
 
 Inspired by Mongoose, OxiMod brings a structured modeling experience while embracing Rust's type safety and performance. It works with any async runtime and is currently tested using `tokio`.
 
+
+### 🚀 New in `v0.1.7` – Fluent API Builders
+
+OxiMod now supports **fluent API builders** and a `new()` method for ergonomic model creation:
+
+```rust
+let user = User::new()
+    .name("Alice".to_string())
+    .age(30)
+    .active(true);
+```
+
+- Supports `Option<T>` and non-optional fields.
+- Works with `#[default("...")]` for seamless defaults.
+- Customize `_id` setter via `#[document_id_setter_ident("...")]`.
+
+Use `user.save().await?` just like before!
+
 ---
 
 ## Features
@@ -32,6 +50,12 @@ Inspired by Mongoose, OxiMod brings a structured modeling experience while embra
 - **Validation Support**  
   Add field-level validation using `#[validate(...)]`. Supports length, email, pattern, positivity, and more.
 
+- **Default Values**  
+  Use `#[default(...)]` to specify field defaults for strings, numbers, and enums.
+
+- **Builder API & `new()` Support**  
+  Use `Model::default()` or `Model::new()` to initialize structs and chain fluent setters. Customize `_id` setter name with `#[document_id_setter_ident(...)]`.
+
 - **Clear Error Handling**  
   Strongly typed, developer-friendly errors based on `thiserror`.
 
@@ -45,6 +69,7 @@ OxiMod supports attributes at both the struct level and field level.
 
 - `#[db("name")]`: Specifies the MongoDB database the model belongs to.
 - `#[collection("name")]`: Specifies the collection name within the database.
+- `#[document_id_setter_ident("name")]`: Optional. Renames the `_id` builder function for fluent `.new()`/`.default()` APIs.
 
 ### Field-Level Index Attributes
 
@@ -79,11 +104,17 @@ You can apply validations on fields using the `#[validate(...)]` attribute.
 
 > 💡 Use native Rust enums instead of `enum_values`.
 
+### Field-Level Default Attributes
+
+- `#[default("value")]`: Assigns a default value for strings.
+- `#[default(42)]`: Sets default for numbers.
+- `#[default(MyEnum::Variant)]`: Sets default for enums.
+
+Accessible via `Model::new()` or `Model::default()`.
+
 ---
 
 ## Example
-
-This example demonstrates how to define a model with schema-level and field-level metadata.
 
 ```rust
 use oximod::{set_global_client, Model};
@@ -109,16 +140,19 @@ struct User {
     #[validate(non_negative)]
     age: i32,
 
+    #[default(false)]
     active: bool,
 }
 ```
 
 In this example:
+
 - `#[db("my_app_db")]` and `#[collection("users")]` configure the database and collection.
 - The `email` field has a descending, unique index with a custom name.
 - The `phone` field is indexed only when it exists in the document (sparse).
 - The `name` field must be at least 3 characters long.
 - The `age` field must be non-negative.
+- The `active` field defaults to `false`.
 
 ---
 
@@ -134,6 +168,7 @@ cargo run --example query
 cargo run --example update
 cargo run --example delete
 cargo run --example by_id
+cargo run --example default_usage
 ```
 
 Each file clears previous data on run and demonstrates isolated functionality.

--- a/oximod/examples/basic_usage.rs
+++ b/oximod/examples/basic_usage.rs
@@ -5,19 +5,19 @@
 //! This demonstrates how to:
 //! - Connect to MongoDB
 //! - Define a model with the `Model` derive macro
-//! - Save a document
+//! - Save a document using the builder API
 //! - Count documents in a collection
 
-
-use oximod::{set_global_client, Model};
-use mongodb::bson::{doc, oid::ObjectId};
-use serde::{Deserialize, Serialize};
+use oximod::{ set_global_client, Model };
+use mongodb::bson::{ doc, oid::ObjectId };
+use serde::{ Deserialize, Serialize };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load MongoDB URI from .env or environment
     dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI")
+    let mongodb_uri = std::env
+        ::var("MONGODB_URI")
         .expect("MONGODB_URI must be set in your .env file or environment");
 
     // Set up the global MongoDB client
@@ -30,23 +30,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
+
         name: String,
         age: i32,
+
+        #[default(true)]
         active: bool,
     }
 
     // Clean up previous runs
     User::clear().await?;
 
-    // Create a new user
-    let user = User {
-        _id: None,
-        name: "User1".to_string(),
-        age: 28,
-        active: true,
-    };
-
-    // Save the user and retrieve the inserted _id
+    // Create and save a user using builder API (defaults `active` to true)
+    let user = User::new().name("User1".to_string()).age(28);
     let id = user.save().await?;
     println!("✅ Saved user with _id: {}", id);
 

--- a/oximod/examples/by_id.rs
+++ b/oximod/examples/by_id.rs
@@ -8,12 +8,13 @@
 //! - Update a document by its `_id`
 //! - Delete a document by its `_id`
 
-use oximod::{set_global_client, Model};
-use mongodb::bson::{doc, oid::ObjectId};
-use serde::{Deserialize, Serialize};
+use oximod::{ set_global_client, Model };
+use mongodb::bson::{ doc, oid::ObjectId };
+use serde::{ Deserialize, Serialize };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load MongoDB URI from environment or .env
     dotenv::dotenv().ok();
     let mongodb_uri = std::env::var("MONGODB_URI")?;
     set_global_client(mongodb_uri).await?;
@@ -26,19 +27,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _id: Option<ObjectId>,
         name: String,
         age: i32,
+        #[default(true)]
         active: bool,
     }
 
     // Clean up previous runs
     User::clear().await?;
 
-    // Insert one user
-    let user = User {
-        _id: None,
-        name: "User1".to_string(),
-        age: 35,
-        active: true,
-    };
+    // Insert one user using the builder API
+    let user = User::new().name("User1".to_string()).age(35); // `active` defaults to true
 
     let id = user.save().await?;
     println!("✅ Inserted user with _id: {}", id);

--- a/oximod/examples/default_usage.rs
+++ b/oximod/examples/default_usage.rs
@@ -1,0 +1,67 @@
+//! Default value example for the oximod crate
+//!
+//! Run with: `cargo run --example default_usage`
+//!
+//! This demonstrates how to:
+//! - Use `#[default(...)]` to assign default values to fields
+//! - Customize `_id` setter via `#[document_id_setter_ident(...)]`
+//! - Use enum and scalar defaults
+//! - Build a model using the fluent API
+
+use oximod::{ set_global_client, Model };
+use mongodb::bson::oid::ObjectId;
+use serde::{ Deserialize, Serialize };
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Status {
+    Active,
+    Inactive,
+    Pending,
+}
+
+#[derive(Debug, Serialize, Deserialize, Model)]
+#[db("default_example_db")]
+#[collection("users")]
+#[document_id_setter_ident("with_mongo_id")]
+struct User {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    _id: Option<ObjectId>,
+
+    #[default("Unnamed".to_string())]
+    name: String,
+
+    #[default(18)]
+    age: i32,
+
+    #[default(false)]
+    verified: bool,
+
+    #[default(Status::Pending)]
+    status: Status,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv::dotenv().ok();
+    let mongodb_uri = std::env::var("MONGODB_URI")?;
+    set_global_client(mongodb_uri).await?;
+
+    // Clear any previous entries
+    User::clear().await?;
+
+    println!("📥 Inserting user with no custom values...");
+    let default_user = User::default().save().await?;
+    println!("✅ Saved user with _id: {}", default_user);
+
+    println!("\n📥 Inserting customized user with fluent API...");
+    let custom_user = User::default()
+        .with_mongo_id(ObjectId::new())
+        .name("User1".to_string())
+        .age(30)
+        .verified(true)
+        .status(Status::Active)
+        .save().await?;
+    println!("✅ Saved custom user with _id: {}", custom_user);
+
+    Ok(())
+}

--- a/oximod/examples/delete.rs
+++ b/oximod/examples/delete.rs
@@ -8,9 +8,9 @@
 //! - Delete a document by ID
 //! - Delete one document with a filter
 
-use oximod::{set_global_client, Model};
-use mongodb::bson::{doc, oid::ObjectId};
-use serde::{Deserialize, Serialize};
+use oximod::{ set_global_client, Model };
+use mongodb::bson::{ doc, oid::ObjectId };
+use serde::{ Deserialize, Serialize };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,15 +26,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _id: Option<ObjectId>,
         name: String,
         age: i32,
+        #[default(true)]
         active: bool,
     }
 
-    // Insert users
+    // Clean up previous runs
+    User::clear().await?;
+
+    // Insert users using builder API
     let users = vec![
-        User { _id: None, name: "User1".into(), age: 20, active: false },
-        User { _id: None, name: "User2".into(), age: 25, active: false },
-        User { _id: None, name: "User3".into(), age: 30, active: true },
-        User { _id: None, name: "User4".into(), age: 30, active: true },
+        User::new().name("User1".to_string()).age(20).active(false),
+        User::new().name("User2".to_string()).age(25).active(false),
+        User::new().name("User3".to_string()).age(30), // active: true by default
+        User::new().name("User4".to_string()).age(30) // active: true by default
     ];
 
     let mut inserted_ids = vec![];
@@ -51,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = User::delete_one(doc! { "active": true }).await?;
     println!("🧹 Deleted {} active user(s)", result.deleted_count);
 
-    // Delete last one by ID
+    // Delete the last one by ID
     if let Some(id) = inserted_ids.pop() {
         let result = User::delete_by_id(id).await?;
         println!("❌ Deleted by ID: {}", result.deleted_count);

--- a/oximod/examples/query.rs
+++ b/oximod/examples/query.rs
@@ -8,9 +8,9 @@
 //! - Query with `find_one`
 //! - Check if a document exists
 
-use oximod::{set_global_client, Model};
-use mongodb::bson::{doc, oid::ObjectId};
-use serde::{Deserialize, Serialize};
+use oximod::{ set_global_client, Model };
+use mongodb::bson::{ doc, oid::ObjectId };
+use serde::{ Deserialize, Serialize };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,17 +26,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _id: Option<ObjectId>,
         name: String,
         age: i32,
+        #[default(true)]
         active: bool,
     }
 
     // Clean up previous runs
     User::clear().await?;
 
-    // Insert multiple users
+    // Insert multiple users using builder API
     let users = vec![
-        User { _id: None, name: "Alice".into(), age: 30, active: true },
-        User { _id: None, name: "Bob".into(), age: 40, active: false },
-        User { _id: None, name: "Charlie".into(), age: 25, active: true },
+        User::new().name("Alice".to_string()).age(30).active(true),
+        User::new().name("Bob".to_string()).age(40).active(false),
+        User::new().name("Charlie".to_string()).age(25).active(true)
     ];
 
     for user in &users {

--- a/oximod/examples/update.rs
+++ b/oximod/examples/update.rs
@@ -6,9 +6,9 @@
 //! - Insert a document
 //! - Update fields using `update` and `update_by_id`
 
-use oximod::{set_global_client, Model};
-use mongodb::bson::{doc, oid::ObjectId};
-use serde::{Deserialize, Serialize};
+use oximod::{ set_global_client, Model };
+use mongodb::bson::{ doc, oid::ObjectId };
+use serde::{ Deserialize, Serialize };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -24,19 +24,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _id: Option<ObjectId>,
         name: String,
         age: i32,
+        #[default(false)]
         active: bool,
     }
 
-    // Insert a user
-    let user = User {
-        _id: None,
-        name: "User1".to_string(),
-        age: 45,
-        active: false,
-    };
-
     // Clean up previous runs
     User::clear().await?;
+
+    // Insert a user
+    let user = User::new().name("User1".to_string()).age(45).active(false);
 
     let id = user.save().await?;
     println!("📝 Inserted user with _id: {}", id);
@@ -44,17 +40,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generic update: Set active = true for all users over 40
     let result = User::update(
         doc! { "age": { "$gt": 40 } },
-        doc! { "$set": { "active": true } },
-    )
-    .await?;
+        doc! { "$set": { "active": true } }
+    ).await?;
     println!("🔁 Updated {} document(s)", result.modified_count);
 
     // Update by ID
-    let result = User::update_by_id(
-        id,
-        doc! { "$set": { "name": "User1 Updated" } },
-    )
-    .await?;
+    let result = User::update_by_id(id, doc! { "$set": { "name": "User1 Updated" } }).await?;
     println!("🆔 Updated {} document(s) by ID", result.modified_count);
 
     Ok(())

--- a/oximod/examples/validate_usage.rs
+++ b/oximod/examples/validate_usage.rs
@@ -8,9 +8,9 @@
 //! - Apply validations like `min_length`, `email`, `positive`, `pattern`, etc.
 //! - Use Rust enums instead of enum_values
 
-use oximod::{set_global_client, Model};
+use oximod::{ set_global_client, Model };
 use mongodb::bson::oid::ObjectId;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 
 #[derive(Debug, Serialize, Deserialize)]
 enum Role {
@@ -46,12 +46,16 @@ struct User {
 
     #[validate(required)]
     role: Option<Role>,
+
+    #[default(false)]
+    active: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI")
+    let mongodb_uri = std::env
+        ::var("MONGODB_URI")
         .expect("MONGODB_URI must be set in your .env file or environment");
 
     set_global_client(mongodb_uri).await?;
@@ -60,31 +64,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     User::clear().await?;
 
     println!("📥 Inserting a valid user...");
-    let valid_user = User {
-        _id: None,
-        username: "arshia".into(),
-        email: Some("arshia@example.com".into()),
-        age: 25,
-        bio: Some("Rustacean and full-stack dev".into()),
-        sku: Some("SKU-1234".into()),
-        points: 0,
-        role: Some(Role::User),
-    };
+    let valid_user = User::new()
+        .username("arshia".to_string())
+        .email("arshia@example.com".to_string())
+        .age(25)
+        .bio("Rustacean and full-stack dev".to_string())
+        .sku("SKU-1234".to_string())
+        .points(0)
+        .role(Role::User)
+        .active(true);
 
     valid_user.save().await?;
     println!("✅ Valid user inserted successfully.");
 
     println!("⚠️ Inserting an invalid user...");
-    let invalid_user = User {
-        _id: None,
-        username: "ab".into(), // too short
-        email: Some("not-an-email".into()),
-        age: -1, // not positive
-        bio: Some("   ".into()), // empty
-        sku: Some("WRONGSKU".into()), // invalid pattern
-        points: -3, // not non-negative
-        role: None, // required
-    };
+    let invalid_user = User::new()
+        .username("ab".to_string()) // too short
+        .email("not-an-email".to_string())
+        .age(-1) // not positive
+        .bio("   ".to_string()) // empty
+        .sku("WRONGSKU".to_string()) // invalid pattern
+        .points(-3); // not non-negative
 
     match invalid_user.save().await {
         Ok(_) => println!("❌ Unexpected success!"),

--- a/oximod/tests/aggregate.rs
+++ b/oximod/tests/aggregate.rs
@@ -1,16 +1,16 @@
-use mongodb::bson::{ doc, oid::ObjectId };
-use oximod::{ set_global_client, Model };
-use testresult::TestResult;
-use serde::{ Deserialize, Serialize };
 use futures_util::stream::StreamExt;
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
+use serde::{ Deserialize, Serialize };
+use testresult::TestResult;
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run aggregates_documents_correctly
 #[tokio::test]
 async fn aggregates_documents_correctly() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -25,21 +25,9 @@ async fn aggregates_documents_correctly() -> TestResult {
     LogEntry::clear().await?;
 
     let logs = vec![
-        LogEntry {
-            _id: None,
-            level: "INFO".to_string(),
-            message: "Startup complete".to_string(),
-        },
-        LogEntry {
-            _id: None,
-            level: "ERROR".to_string(),
-            message: "Failed to connect".to_string(),
-        },
-        LogEntry {
-            _id: None,
-            level: "INFO".to_string(),
-            message: "Listening on port 3000".to_string(),
-        }
+        LogEntry::default().level("INFO".to_string()).message("Startup complete".to_string()),
+        LogEntry::default().level("ERROR".to_string()).message("Failed to connect".to_string()),
+        LogEntry::default().level("INFO".to_string()).message("Listening on port 3000".to_string())
     ];
 
     for log in logs {

--- a/oximod/tests/builder_api.rs
+++ b/oximod/tests/builder_api.rs
@@ -32,10 +32,10 @@ async fn new_and_default_are_equivalent() -> TestResult {
 #[tokio::test]
 async fn builder_sets_all_fields() -> TestResult {
     let id = ObjectId::new();
-    let user = User::default().id(id.clone()).name("Alice".to_string()).age(30).active(true);
+    let user = User::default().id(id.clone()).name("User1".to_string()).age(30).active(true);
 
     assert_eq!(user._id, Some(id));
-    assert_eq!(user.name, "Alice");
+    assert_eq!(user.name, "User1");
     assert_eq!(user.age, 30);
     assert!(user.active);
 
@@ -45,10 +45,10 @@ async fn builder_sets_all_fields() -> TestResult {
 // Run test: cargo nextest run builder_partial_fields_default_rest
 #[tokio::test]
 async fn builder_partial_fields_default_rest() -> TestResult {
-    let user = User::default().name("Bob".to_string());
+    let user = User::default().name("User1".to_string());
 
     // name should be set, rest should be their respective defaults
-    assert_eq!(user.name, "Bob");
+    assert_eq!(user.name, "User1");
     assert_eq!(user.age, 0);
     assert_eq!(user.active, false);
     assert_eq!(user._id, None);
@@ -62,7 +62,7 @@ async fn builder_and_save_works_end_to_end() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let saved_id = User::default().name("Charlie".to_string()).age(42).active(true).save().await?;
+    let saved_id = User::default().name("User1".to_string()).age(42).active(true).save().await?;
 
     assert_ne!(saved_id, ObjectId::default());
 
@@ -70,7 +70,7 @@ async fn builder_and_save_works_end_to_end() -> TestResult {
     assert!(fetched.is_some());
 
     let user = fetched.unwrap();
-    assert_eq!(user.name, "Charlie");
+    assert_eq!(user.name, "User1");
     assert_eq!(user.age, 42);
     assert!(user.active);
 

--- a/oximod/tests/builder_api.rs
+++ b/oximod/tests/builder_api.rs
@@ -1,0 +1,78 @@
+mod common;
+
+use common::init;
+use mongodb::bson::oid::ObjectId;
+use oximod::Model;
+use serde::{ Deserialize, Serialize };
+use testresult::TestResult;
+
+/// A simple model used to test the `new`, `default`, and builder APIs.
+#[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
+#[db("test")]
+#[collection("builder_tests")]
+pub struct User {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    _id: Option<ObjectId>,
+    name: String,
+    age: i32,
+    active: bool,
+}
+
+// Run test: cargo nextest run new_and_default_are_equivalent
+#[tokio::test]
+async fn new_and_default_are_equivalent() -> TestResult {
+    let user_new = User::new();
+    let user_default = User::default();
+
+    assert_eq!(user_new, user_default);
+    Ok(())
+}
+
+// Run test: cargo nextest run builder_sets_all_fields
+#[tokio::test]
+async fn builder_sets_all_fields() -> TestResult {
+    let id = ObjectId::new();
+    let user = User::default().id(id.clone()).name("Alice".to_string()).age(30).active(true);
+
+    assert_eq!(user._id, Some(id));
+    assert_eq!(user.name, "Alice");
+    assert_eq!(user.age, 30);
+    assert!(user.active);
+
+    Ok(())
+}
+
+// Run test: cargo nextest run builder_partial_fields_default_rest
+#[tokio::test]
+async fn builder_partial_fields_default_rest() -> TestResult {
+    let user = User::default().name("Bob".to_string());
+
+    // name should be set, rest should be their respective defaults
+    assert_eq!(user.name, "Bob");
+    assert_eq!(user.age, 0);
+    assert_eq!(user.active, false);
+    assert_eq!(user._id, None);
+
+    Ok(())
+}
+
+// Run test: cargo nextest run builder_and_save_works_end_to_end
+#[tokio::test]
+async fn builder_and_save_works_end_to_end() -> TestResult {
+    init().await;
+    User::clear().await?;
+
+    let saved_id = User::default().name("Charlie".to_string()).age(42).active(true).save().await?;
+
+    assert_ne!(saved_id, ObjectId::default());
+
+    let fetched = User::find_by_id(saved_id).await?;
+    assert!(fetched.is_some());
+
+    let user = fetched.unwrap();
+    assert_eq!(user.name, "Charlie");
+    assert_eq!(user.age, 42);
+    assert!(user.active);
+
+    Ok(())
+}

--- a/oximod/tests/clear.rs
+++ b/oximod/tests/clear.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run clears_collection_successfully
 #[tokio::test]
 async fn clears_collection_successfully() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -23,18 +23,8 @@ async fn clears_collection_successfully() -> TestResult {
     }
 
     let users = vec![
-        User {
-            _id: None,
-            name: "User1".to_string(),
-            age: 22,
-            active: true,
-        },
-        User {
-            _id: None,
-            name: "User2".to_string(),
-            age: 28,
-            active: false,
-        },
+        User::default().name("User1".to_string()).age(22).active(true),
+        User::default().name("User2".to_string()).age(28).active(false)
     ];
 
     for user in users {
@@ -45,7 +35,6 @@ async fn clears_collection_successfully() -> TestResult {
     assert!(count_before >= 2);
 
     let result = User::clear().await?;
-
     assert!(result.deleted_count >= 2);
 
     Ok(())

--- a/oximod/tests/connection.rs
+++ b/oximod/tests/connection.rs
@@ -1,13 +1,13 @@
-use oximod_core::feature::conn::client::{get_global_client, set_global_client};
+use oximod_core::feature::conn::client::get_global_client;
 use testresult::TestResult;
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run connects_to_db_successfully
 #[tokio::test]
 async fn connects_to_db_successfully() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     get_global_client().unwrap_or_else(|e| panic!("{}", e));
 

--- a/oximod/tests/count.rs
+++ b/oximod/tests/count.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run counts_matching_documents_correctly
 #[tokio::test]
 async fn counts_matching_documents_correctly() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -25,24 +25,9 @@ async fn counts_matching_documents_correctly() -> TestResult {
     User::clear().await?;
 
     let users = vec![
-        User {
-            _id: None,
-            name: "User1".to_string(),
-            age: 30,
-            active: true,
-        },
-        User {
-            _id: None,
-            name: "User3".to_string(),
-            age: 30,
-            active: false,
-        },
-        User {
-            _id: None,
-            name: "User3".to_string(),
-            age: 25,
-            active: true,
-        },
+        User::default().name("User1".to_string()).age(30).active(true),
+        User::default().name("User3".to_string()).age(30).active(false),
+        User::default().name("User3".to_string()).age(25).active(true)
     ];
 
     for user in users {

--- a/oximod/tests/default.rs
+++ b/oximod/tests/default.rs
@@ -53,7 +53,7 @@ async fn override_default_values() -> TestResult {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
 
-        #[default("\"Guest\"".to_string())]
+        #[default("Guest".to_string())]
         user: String,
 
         #[default(1)]

--- a/oximod/tests/default.rs
+++ b/oximod/tests/default.rs
@@ -1,0 +1,117 @@
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
+use testresult::TestResult;
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
+
+// Run test: cargo nextest run saves_with_default_string_and_number
+#[tokio::test]
+async fn saves_with_default_string_and_number() -> TestResult {
+    init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("defaults_str_num")]
+    pub struct Thing {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[default("Anonymous".to_string())]
+        name: String,
+
+        #[default(0)]
+        count: i32,
+    }
+
+    Thing::clear().await?;
+
+    // We don't call `.name(...)` or `.count(...)` so defaults should apply:
+    let thing = Thing::default();
+    let id = thing.save().await?;
+
+    // Fetch raw document to inspect defaults:
+    let doc = Thing::find_one(doc! { "_id": id.clone() }).await?
+        .unwrap();
+
+    assert_eq!(doc.name, "Anonymous");
+    assert_eq!(doc.count, 0);
+
+    Ok(())
+}
+
+// Run test: cargo nextest run override_default_values
+#[tokio::test]
+async fn override_default_values() -> TestResult {
+    init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("defaults_override")]
+    pub struct Record {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[default("\"Guest\"".to_string())]
+        user: String,
+
+        #[default(1)]
+        retries: i32,
+    }
+
+    Record::clear().await?;
+
+    // Override both defaults via fluent API:
+    let rec = Record::default().user("Alice".to_string()).retries(5);
+    let id = rec.save().await?;
+
+    let got = Record::find_by_id(id).await?.unwrap();
+    assert_eq!(got.user, "Alice");
+    assert_eq!(got.retries, 5);
+
+    Ok(())
+}
+
+// Run test: cargo nextest run enum_default_and_override
+#[tokio::test]
+async fn enum_default_and_override() -> TestResult {
+    init().await;
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    pub enum Status {
+        Pending,
+        Complete,
+    }
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("defaults_enum")]
+    pub struct Task {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[default(Status::Pending)]
+        status: Status,
+
+        description: String,
+    }
+
+    Task::clear().await?;
+
+    // Without overriding, status == Pending
+    let t1 = Task::default().description("T1".into());
+    let id1 = t1.save().await?;
+    let got1 = Task::find_by_id(id1).await?.unwrap();
+    assert_eq!(got1.status, Status::Pending);
+    assert_eq!(got1.description, "T1");
+
+    // Override to Complete
+    let t2 = Task::default().status(Status::Complete).description("T2".into());
+    let id2 = t2.save().await?;
+    let got2 = Task::find_by_id(id2).await?.unwrap();
+    assert_eq!(got2.status, Status::Complete);
+    assert_eq!(got2.description, "T2");
+
+    Ok(())
+}

--- a/oximod/tests/delete.rs
+++ b/oximod/tests/delete.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run deletes_multiple_matching_documents
 #[tokio::test]
 async fn deletes_multiple_matching_documents() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -25,24 +25,9 @@ async fn deletes_multiple_matching_documents() -> TestResult {
     User::clear().await?;
 
     let users = vec![
-        User {
-            _id: None,
-            name: "User1".to_string(),
-            age: 45,
-            active: false,
-        },
-        User {
-            _id: None,
-            name: "User2".to_string(),
-            age: 38,
-            active: false,
-        },
-        User {
-            _id: None,
-            name: "User3".to_string(),
-            age: 38,
-            active: true,
-        },
+        User::default().name("User1".to_string()).age(45).active(false),
+        User::default().name("User2".to_string()).age(38).active(false),
+        User::default().name("User3".to_string()).age(38).active(true)
     ];
 
     for user in users {

--- a/oximod/tests/delete_one.rs
+++ b/oximod/tests/delete_one.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run deletes_first_matching_document_only
 #[tokio::test]
 async fn deletes_first_matching_document_only() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -25,18 +25,8 @@ async fn deletes_first_matching_document_only() -> TestResult {
     User::clear().await?;
 
     let users = vec![
-        User {
-            _id: None,
-            name: "User1".to_string(),
-            age: 50,
-            active: false,
-        },
-        User {
-            _id: None,
-            name: "User2".to_string(),
-            age: 50,
-            active: false,
-        },
+        User::default().name("User1".to_string()).age(50).active(false),
+        User::default().name("User2".to_string()).age(50).active(false)
     ];
 
     for user in users {

--- a/oximod/tests/exists.rs
+++ b/oximod/tests/exists.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run checks_existence_of_matching_document
 #[tokio::test]
 async fn checks_existence_of_matching_document() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -24,12 +24,7 @@ async fn checks_existence_of_matching_document() -> TestResult {
 
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "User1".to_string(),
-        age: 27,
-        active: true,
-    };
+    let user = User::default().name("User1".to_string()).age(27).active(true);
 
     user.save().await?;
 

--- a/oximod/tests/find.rs
+++ b/oximod/tests/find.rs
@@ -1,15 +1,15 @@
 use mongodb::bson::{ doc, oid::ObjectId };
-use oximod::{set_global_client, Model};
+use oximod::Model;
 use testresult::TestResult;
 use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run finds_multiple_matching_documents
 #[tokio::test]
 async fn finds_multiple_matching_documents() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -25,24 +25,9 @@ async fn finds_multiple_matching_documents() -> TestResult {
     User::clear().await?;
 
     let users = vec![
-        User {
-            _id: None,
-            name: "User1".to_string(),
-            age: 28,
-            active: true,
-        },
-        User {
-            _id: None,
-            name: "User2".to_string(),
-            age: 28,
-            active: true,
-        },
-        User {
-            _id: None,
-            name: "User3".to_string(),
-            age: 35,
-            active: true,
-        }
+        User::default().name("User1".to_string()).age(28).active(true),
+        User::default().name("User2".to_string()).age(28).active(true),
+        User::default().name("User3".to_string()).age(35).active(true)
     ];
 
     for user in users {

--- a/oximod/tests/find_by_id.rs
+++ b/oximod/tests/find_by_id.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run finds_document_by_id_correctly
 #[tokio::test]
 async fn finds_document_by_id_correctly() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -24,14 +24,9 @@ async fn finds_document_by_id_correctly() -> TestResult {
 
     User::clear().await?;
 
-    let user = User {
-        _id: Some(ObjectId::new()),
-        name: "User1".to_string(),
-        age: 33,
-        active: true,
-    };
+    let id = ObjectId::new();
+    let user = User::default().id(id.clone()).name("User1".to_string()).age(33).active(true);
 
-    let id = user._id.unwrap();
     user.save().await?;
 
     let found = User::find_by_id(id).await?;

--- a/oximod/tests/find_one.rs
+++ b/oximod/tests/find_one.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run finds_first_matching_document_correctly
 #[tokio::test]
 async fn finds_first_matching_document_correctly() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
@@ -21,22 +21,12 @@ async fn finds_first_matching_document_correctly() -> TestResult {
         age: i32,
         active: bool,
     }
-    
+
     User::clear().await?;
 
     let users = vec![
-        User {
-            _id: None,
-            name: "User1".to_string(),
-            age: 22,
-            active: true,
-        },
-        User {
-            _id: None,
-            name: "User2".to_string(),
-            age: 22,
-            active: false,
-        },
+        User::default().name("User1".to_string()).age(22).active(true),
+        User::default().name("User2".to_string()).age(22).active(false)
     ];
 
     for user in users {

--- a/oximod/tests/update_by_id.rs
+++ b/oximod/tests/update_by_id.rs
@@ -1,15 +1,15 @@
-use mongodb::bson::{doc, oid::ObjectId};
-use oximod::{set_global_client, Model};
+use mongodb::bson::{ doc, oid::ObjectId };
+use oximod::Model;
 use testresult::TestResult;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
+
+mod common;
+use common::init;
 
 // Run test: cargo nextest run updates_document_by_id_correctly
 #[tokio::test]
 async fn updates_document_by_id_correctly() -> TestResult {
-    dotenv::dotenv().ok();
-    let mongodb_uri = std::env::var("MONGODB_URI").expect("Failed to find MONGODB_URI");
-
-    set_global_client(mongodb_uri).await.unwrap_or_else(|e| panic!("{}", e));
+    init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("ptest")]
@@ -24,14 +24,9 @@ async fn updates_document_by_id_correctly() -> TestResult {
 
     User::clear().await?;
 
-    let user = User {
-        _id: Some(ObjectId::new()),
-        name: "User1".to_string(),
-        age: 31,
-        active: true,
-    };
+    let id = ObjectId::new();
+    let user = User::default().id(id.clone()).name("User1".to_string()).age(31).active(true);
 
-    let id = user._id.unwrap();
     user.save().await?;
 
     // Update age to 32

--- a/oximod/tests/validate_email.rs
+++ b/oximod/tests/validate_email.rs
@@ -3,7 +3,7 @@ mod common;
 use common::init;
 use mongodb::bson::oid::ObjectId;
 use oximod::Model;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -36,12 +36,10 @@ async fn test_missing_at_symbol() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "Valid".to_string(),
-        email: Some("invalidemail.com".to_string()), // ❌ missing '@'
-        role: Some(Role::Admin),
-    };
+    let user = User::default()
+        .name("Valid".to_string())
+        .email("invalidemail.com".to_string())
+        .role(Role::Admin);
 
     let err = user.save().await;
     assert!(err.is_err());
@@ -55,12 +53,10 @@ async fn test_missing_domain_dot() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "Valid".to_string(),
-        email: Some("user@domain".to_string()), // ❌ missing .com, .net, etc.
-        role: Some(Role::Admin),
-    };
+    let user = User::default()
+        .name("Valid".to_string())
+        .email("user@domain".to_string())
+        .role(Role::Admin);
 
     let err = user.save().await;
     assert!(err.is_err());
@@ -74,12 +70,10 @@ async fn test_valid_email() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "Valid".to_string(),
-        email: Some("user@example.com".to_string()), // ✅ valid
-        role: Some(Role::Guess),
-    };
+    let user = User::default()
+        .name("Valid".to_string())
+        .email("user@example.com".to_string())
+        .role(Role::Guess);
 
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());

--- a/oximod/tests/validate_length.rs
+++ b/oximod/tests/validate_length.rs
@@ -3,7 +3,7 @@ mod common;
 use common::init;
 use mongodb::bson::oid::ObjectId;
 use oximod::Model;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -36,12 +36,10 @@ async fn test_min_length_violation() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "abc".to_string(), // too short
-        email: Some("x@y.com".to_string()),
-        role: Some(Role::Admin),
-    };
+    let user = User::default()
+        .name("abc".to_string()) // too short
+        .email("x@y.com".to_string())
+        .role(Role::Admin);
 
     let err = user.save().await;
     assert!(err.is_err());
@@ -56,12 +54,10 @@ async fn test_max_length_violation() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "ThisNameIsWayTooLong".to_string(), // too long
-        email: Some("x@y.com".to_string()),
-        role: Some(Role::Admin),
-    };
+    let user = User::default()
+        .name("ThisNameIsWayTooLong".to_string()) // too long
+        .email("x@y.com".to_string())
+        .role(Role::Admin);
 
     let err = user.save().await;
     assert!(err.is_err());
@@ -76,12 +72,10 @@ async fn test_length_valid() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "ValidName".to_string(), // valid
-        email: Some("user@example.com".to_string()),
-        role: Some(Role::Admin),
-    };
+    let user = User::default()
+        .name("ValidName".to_string()) // valid
+        .email("user@example.com".to_string())
+        .role(Role::Admin);
 
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());

--- a/oximod/tests/validate_min_and_max.rs
+++ b/oximod/tests/validate_min_and_max.rs
@@ -3,7 +3,7 @@ mod common;
 use common::init;
 use mongodb::bson::oid::ObjectId;
 use oximod::Model;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
 #[derive(Model, Serialize, Deserialize, Debug)]
@@ -14,13 +14,13 @@ pub struct Book {
     _id: Option<ObjectId>,
 
     #[validate(min = 100)]
-    pages: i32, 
+    pages: i32,
 
     #[validate(max = 100)]
-    price: i32, 
+    price: i32,
 
     #[validate(min = 1900, max = 2025)]
-    year: i32, 
+    year: i32,
 }
 
 // Run test: cargo nextest run test_book_min_violation
@@ -29,12 +29,10 @@ async fn test_book_min_violation() -> TestResult {
     init().await;
     Book::clear().await?;
 
-    let book = Book {
-        _id: None,
-        pages: 99, // ❌ below min
-        price: 80,
-        year: 2000,
-    };
+    let book = Book::default()
+        .pages(99) // ❌ below min
+        .price(80)
+        .year(2000);
 
     let err = book.save().await;
     assert!(err.is_err());
@@ -48,12 +46,10 @@ async fn test_book_max_violation() -> TestResult {
     init().await;
     Book::clear().await?;
 
-    let book = Book {
-        _id: None,
-        pages: 120,
-        price: 150, // ❌ above max
-        year: 2000,
-    };
+    let book = Book::default()
+        .pages(120)
+        .price(150) // ❌ above max
+        .year(2000);
 
     let err = book.save().await;
     assert!(err.is_err());
@@ -67,12 +63,7 @@ async fn test_book_valid() -> TestResult {
     init().await;
     Book::clear().await?;
 
-    let book = Book {
-        _id: None,
-        pages: 120,
-        price: 90,
-        year: 2022,
-    };
+    let book = Book::default().pages(120).price(90).year(2022);
 
     let result = book.save().await?;
     assert_ne!(result, ObjectId::default());

--- a/oximod/tests/validate_pattern.rs
+++ b/oximod/tests/validate_pattern.rs
@@ -3,7 +3,7 @@ mod common;
 use common::init;
 use mongodb::bson::oid::ObjectId;
 use oximod::Model;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
 #[derive(Model, Serialize, Deserialize, Debug)]
@@ -35,14 +35,12 @@ async fn test_invalid_pattern_format() -> TestResult {
     init().await;
     Product::clear().await?;
 
-    let product = Product {
-        _id: None,
-        code: Some("BAD-SKU".to_string()), // ❌ does not match ^SKU-\d{4}$
-        name: Some("Product1".to_string()),
-        quantity: 10,
-        temperature: -10,
-        rating: 5,
-    };
+    let product = Product::default()
+        .code("BAD-SKU".to_string()) // ❌ does not match ^SKU-\d{4}$
+        .name("Product1".to_string())
+        .quantity(10)
+        .temperature(-10)
+        .rating(5);
 
     let err = product.save().await;
     assert!(err.is_err());
@@ -56,14 +54,12 @@ async fn test_valid_pattern_format() -> TestResult {
     init().await;
     Product::clear().await?;
 
-    let product = Product {
-        _id: None,
-        code: Some("SKU-1234".to_string()), // ✅ matches pattern
-        name: Some("Product1".to_string()),
-        quantity: 10,
-        temperature: -10,
-        rating: 5,
-    };
+    let product = Product::default()
+        .code("SKU-1234".to_string()) // ✅ matches pattern
+        .name("Product1".to_string())
+        .quantity(10)
+        .temperature(-10)
+        .rating(5);
 
     let result = product.save().await?;
     assert_ne!(result, ObjectId::default());

--- a/oximod/tests/validate_required_enum.rs
+++ b/oximod/tests/validate_required_enum.rs
@@ -3,7 +3,7 @@ mod common;
 use common::init;
 use mongodb::bson::oid::ObjectId;
 use oximod::Model;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -36,12 +36,7 @@ async fn test_missing_required_email() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "Valid".to_string(),
-        email: None, // ❌ required
-        role: Some(Role::User),
-    };
+    let user = User::default().name("Valid".to_string()).role(Role::User); // ❌ missing email
 
     let err = user.save().await;
     assert!(err.is_err());
@@ -55,12 +50,7 @@ async fn test_missing_required_role() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "Valid".to_string(),
-        email: Some("user@example.com".to_string()),
-        role: None, // ❌ required
-    };
+    let user = User::default().name("Valid".to_string()).email("user@example.com".to_string()); // ❌ missing role
 
     let err = user.save().await;
     assert!(err.is_err());
@@ -74,12 +64,10 @@ async fn test_valid_required_enum() -> TestResult {
     init().await;
     User::clear().await?;
 
-    let user = User {
-        _id: None,
-        name: "Valid".to_string(),
-        email: Some("user@example.com".to_string()),
-        role: Some(Role::Admin), // ✅ allowed enum
-    };
+    let user = User::default()
+        .name("Valid".to_string())
+        .email("user@example.com".to_string())
+        .role(Role::Admin); // ✅ allowed enum
 
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());

--- a/oximod_core/Cargo.toml
+++ b/oximod_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oximod_core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Arshia Eskandari <email@arshiaeskandari.com>"]
 description = "The core logic and error handling for OxiMod, a MongoDB ODM for Rust."

--- a/oximod_macros/Cargo.toml
+++ b/oximod_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oximod_macros"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Arshia Eskandari <email@arshiaeskandari.com>"]
 description = "Procedural macros for the OxiMod MongoDB ODM."
@@ -19,5 +19,5 @@ quote = "1.0.38"
 proc-macro2 = "1.0.93"
 mongodb = "3.2.1"
 thiserror = "2.0.11"
-oximod_core = { version = "0.1.6", path = "../oximod_core" }
+oximod_core = { version = "0.1.7", path = "../oximod_core" }
 futures-util = "0.3.31"

--- a/oximod_macros/src/lib.rs
+++ b/oximod_macros/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ parse_macro_input, Attribute, DeriveInput, Lit, LitStr };
@@ -238,22 +240,22 @@ fn parse_validate_args(attr: &Attribute, field_name: String) -> syn::Result<Vali
                 }
             } else if meta.path.is_ident("required") {
                 args.required = Some(true);
-            // } else if meta.path.is_ident("enum_values") {
-            //     // 1. Grab the parenthesized group
-            //     let content;
-            //     syn::parenthesized!(content in meta.input);
+                // } else if meta.path.is_ident("enum_values") {
+                //     // 1. Grab the parenthesized group
+                //     let content;
+                //     syn::parenthesized!(content in meta.input);
 
-            //     // 2. Parse a comma-separated list of string literals
-            //     let values = content
-            //         .parse_terminated(
-            //             |buf: &syn::parse::ParseBuffer| buf.parse::<syn::LitStr>(), // note the closure
-            //             syn::Token![,]
-            //         )?
-            //         .into_iter()
-            //         .map(|lit_str| lit_str.value())
-            //         .collect::<Vec<_>>();
+                //     // 2. Parse a comma-separated list of string literals
+                //     let values = content
+                //         .parse_terminated(
+                //             |buf: &syn::parse::ParseBuffer| buf.parse::<syn::LitStr>(), // note the closure
+                //             syn::Token![,]
+                //         )?
+                //         .into_iter()
+                //         .map(|lit_str| lit_str.value())
+                //         .collect::<Vec<_>>();
 
-            //     args.enum_values = Some(values);
+                //     args.enum_values = Some(values);
             } else if meta.path.is_ident("email") {
                 args.email = Some(true);
             } else if meta.path.is_ident("pattern") {
@@ -298,7 +300,55 @@ fn parse_validate_args(attr: &Attribute, field_name: String) -> syn::Result<Vali
     Ok(ValidateDefinition { field_name, args })
 }
 
-#[proc_macro_derive(Model, attributes(db, collection, index, validate))]
+struct DefaultDefinition {
+    field_ident: syn::Ident,
+    default_lit: Lit, // could be LitStr, LitInt, or a path-like literal
+}
+
+fn parse_default_args(attr: &Attribute, field_ident: &syn::Ident) -> Option<DefaultDefinition> {
+    let mut lit_opt = None;
+    attr
+        .parse_nested_meta(|meta| {
+            if meta.path.is_ident("default") {
+                lit_opt = Some(meta.value()?.parse()?);
+            }
+            Ok(())
+        })
+        .ok()?;
+
+    lit_opt.map(|lit| DefaultDefinition {
+        field_ident: field_ident.clone(),
+        default_lit: lit,
+    })
+}
+
+use syn::{ Type, PathArguments, GenericArgument };
+
+/// If `ty` is `Option<Inner>`, returns `Some(&Inner)`, otherwise `None`.
+fn option_inner_type(ty: &Type) -> Option<&Type> {
+    // We only care about a simple `Option<...>` path type
+    if let Type::Path(type_path) = ty {
+        // Must be exactly one segment, i.e. `Option`
+        if type_path.path.segments.len() == 1 {
+            let segment = &type_path.path.segments[0];
+            if segment.ident == "Option" {
+                // Look for the angle-bracketed args: `<Inner>`
+                if let PathArguments::AngleBracketed(params) = &segment.arguments {
+                    // We expect exactly one generic argument
+                    if params.args.len() == 1 {
+                        // And that argument must itself be a type
+                        if let GenericArgument::Type(inner_ty) = &params.args[0] {
+                            return Some(inner_ty);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[proc_macro_derive(Model, attributes(db, collection, index, validate, default))]
 /// Procedural macro to derive the `Model` trait for mongodb schema support.
 ///
 /// This macro enables automatic implementation of the `Model` trait, allowing
@@ -334,6 +384,8 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     let mut collection: Option<LitStr> = None;
     let mut index_definitions = Vec::new();
     let mut validate_definitions = Vec::new();
+    let mut default_definitions = Vec::new();
+    let mut all_fields: Vec<(syn::Ident, syn::Type)> = Vec::new();
 
     for attr in &input.attrs {
         if attr.path().is_ident("db") {
@@ -379,24 +431,25 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 
     if let syn::Data::Struct(data_struct) = &input.data {
         for field in data_struct.fields.iter() {
-            for attr in &field.attrs {
-                if attr.path().is_ident("index") {
-                    if let Some(ident) = &field.ident {
-                        let field_name = ident.to_string();
-                        let index_args = parse_index_args(attr, field_name).expect(
+            if let Some(ident) = &field.ident {
+                all_fields.push((ident.clone(), field.ty.clone()));
+                for attr in &field.attrs {
+                    let field_name = ident.to_string();
+                    if attr.path().is_ident("index") {
+                        let index_args = parse_index_args(attr, field_name.clone()).expect(
                             "could not parse index args"
                         );
-
                         index_definitions.push(index_args); // <-- COLLECT
-                    }
-                } else if attr.path().is_ident("validate") {
-                    if let Some(ident) = &field.ident {
-                        let field_name = ident.to_string();
-                        let validate_definition = parse_validate_args(attr, field_name).expect(
-                            "could nhot parse validate args"
-                        );
-
+                    } else if attr.path().is_ident("validate") {
+                        let validate_definition = parse_validate_args(
+                            attr,
+                            field_name.clone()
+                        ).expect("could not parse validate args");
                         validate_definitions.push(validate_definition);
+                    } else if attr.path().is_ident("default") {
+                        if let Some(def) = parse_default_args(attr, ident) {
+                            default_definitions.push(def);
+                        }
                     }
                 }
             }
@@ -667,6 +720,42 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
         checks
     });
 
+    let default_inits = default_definitions.iter().map(|def| {
+        let ident = &def.field_ident;
+        let lit = &def.default_lit;
+        quote! { #ident: (#lit).into(), }
+    });
+
+    let default_idents: HashSet<String> = default_definitions
+    .iter()
+    .map(|d| d.field_ident.to_string())
+    .collect();
+
+    let other_inits = all_fields
+        .iter()
+        .filter(|(ident, _ty)| !default_idents.contains(&ident.to_string()))
+        .map(|(ident, _ty)| {
+            quote! { #ident: Default::default(), }
+        });
+
+    let setters = all_fields.iter().map(|(ident, ty)| {
+        if let Some(inner_ty) = option_inner_type(ty) {
+            quote! {
+                pub fn #ident<T: Into<#inner_ty>>(mut self, val: T) -> Self {
+                    self.#ident = Some(val.into());
+                    self
+                }
+            }
+        } else {
+            quote! {
+                pub fn #ident(mut self, val: #ty) -> Self {
+                    self.#ident = val;
+                    self
+                }
+            }
+        }
+    });
+
     let expanded =
         quote! {
 
@@ -696,6 +785,19 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     
                 Ok(())
             }
+
+            pub fn new() -> Self {
+                #name {
+                    #(#default_inits)*
+                    #(#other_inits)*
+                }
+            }
+        
+            #(#setters)*
+        }
+
+        impl ::std::default::Default for #name {
+            fn default() -> Self { Self::new() }
         }
 
         #[::oximod::_async_trait::async_trait]


### PR DESCRIPTION
## 🚀 Introduce Fluent API Builders with #[default()] Support

### Summary

This PR introduces a powerful and ergonomic **Fluent API builder pattern** for OxiMod models using `#[default()]`, `new()`, and custom setters.

### ✅ Highlights

- 🧱 **`#[default()]` Attribute Support**  
  Fields can now be pre-populated with default values using a declarative `#[default("value")]` style.

- 🔨 **`new()` Constructor for Models**  
  Automatically calls `Default::default()` with support for default field values defined via attributes.

- 🔁 **Fluent Builder API**  
  All models now come with builder-style methods:
  ```rust
  let user = User::new()
      .name("Alice")
      .age(30)
      .active(true)
      .save()
      .await?;
