### PR TITLE
Feat/12/indexes and validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ You can add indexes to fields using the `#[index(...)]` attribute.
 - `background`: Builds index in the background without locking the database.
 - `order = 1 | -1`: Index sort order (1 = ascending, -1 = descending).
 - `expire_after_secs = ...`: Time-to-live for the index in seconds.
+- `version = N`: Specifies the index version (e.g., 1, 2, etc.).
+- `text_index_version = N`: Specifies the text index version (1, 2, 3, etc.). Use only with text indexes.
+- `hidden`: If true, the index is created but hidden from the query planner by default.
 
 ### Field-Level Validation Attributes
 
@@ -100,6 +103,11 @@ You can apply validations on fields using the `#[validate(...)]` attribute.
 - `non_negative`: Ensures numeric value is 0 or greater.
 - `min = N`: Ensures numeric value is at least `N`.
 - `max = N`: Ensures numeric value is at most `N`.
+- `starts_with = "..."`: Ensures a string starts with the given prefix.
+- `ends_with = "..."`: Ensures a string ends with the given suffix.
+- `includes = "..."`: Ensures a string includes the given substring.
+- `alphanumeric`: Ensures all characters are alphanumeric.
+- `multiple_of = N`: Ensures the numeric value is a multiple of `N`.
 
 > 💡 Use native Rust enums instead of `enum_values`.
 
@@ -139,6 +147,12 @@ struct User {
     #[validate(non_negative)]
     age: i32,
 
+    #[validate(non_negative, multiple_of = 5)]
+    points: i32,
+
+    #[index(hidden)]
+    internal_tag: String,
+
     #[default(false)]
     active: bool,
 }
@@ -151,6 +165,8 @@ In this example:
 - The `phone` field is indexed only when it exists in the document (sparse).
 - The `name` field must be at least 3 characters long.
 - The `age` field must be non-negative.
+- The `points` field must be non-negative and a multiple of 5.
+- The `internal_tag` field is indexed but hidden from query planning, useful for internal/system metadata. 
 - The `active` field defaults to `false`.
 
 ---

--- a/oximod/Cargo.toml
+++ b/oximod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oximod"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Arshia Eskandari <email@arshiaeskandari.com>"]
 description = "MongoDB ODM for Rust inspired by Mongoose"
@@ -15,7 +15,7 @@ async-trait = "0.1.86"
 mongodb = "3.2.1"
 thiserror = "2.0.11"
 oximod_core = { version = "0.1.9", path = "../oximod_core" }
-oximod_macros = { version = "0.1.10", path = "../oximod_macros" }
+oximod_macros = { version = "0.1.11", path = "../oximod_macros" }
 serde = "1.0.219"
 futures-util = "0.3.31"
 regex = "1.11.1"

--- a/oximod/README.md
+++ b/oximod/README.md
@@ -10,7 +10,6 @@ OxiMod is a schema-based Object-Document Mapper (ODM) for MongoDB, designed for 
 
 Inspired by Mongoose, OxiMod brings a structured modeling experience while embracing Rust's type safety and performance. It works with any async runtime and is currently tested using `tokio`.
 
-
 ### 🚀 Highlighted Feature (since `v0.1.7`) – Fluent API Builders
 
 OxiMod now supports **fluent API builders** and a `new()` method for ergonomic model creation:
@@ -83,6 +82,9 @@ You can add indexes to fields using the `#[index(...)]` attribute.
 - `background`: Builds index in the background without locking the database.
 - `order = 1 | -1`: Index sort order (1 = ascending, -1 = descending).
 - `expire_after_secs = ...`: Time-to-live for the index in seconds.
+- `version = N`: Specifies the index version (e.g., 1, 2, etc.).
+- `text_index_version = N`: Specifies the text index version (1, 2, 3, etc.). Use only with text indexes.
+- `hidden`: If true, the index is created but hidden from the query planner by default.
 
 ### Field-Level Validation Attributes
 
@@ -101,6 +103,11 @@ You can apply validations on fields using the `#[validate(...)]` attribute.
 - `non_negative`: Ensures numeric value is 0 or greater.
 - `min = N`: Ensures numeric value is at least `N`.
 - `max = N`: Ensures numeric value is at most `N`.
+- `starts_with = "..."`: Ensures a string starts with the given prefix.
+- `ends_with = "..."`: Ensures a string ends with the given suffix.
+- `includes = "..."`: Ensures a string includes the given substring.
+- `alphanumeric`: Ensures all characters are alphanumeric.
+- `multiple_of = N`: Ensures the numeric value is a multiple of `N`.
 
 > 💡 Use native Rust enums instead of `enum_values`.
 
@@ -140,6 +147,12 @@ struct User {
     #[validate(non_negative)]
     age: i32,
 
+    #[validate(non_negative, multiple_of = 5)]
+    points: i32,
+
+    #[index(hidden)]
+    internal_tag: String,
+
     #[default(false)]
     active: bool,
 }
@@ -152,6 +165,8 @@ In this example:
 - The `phone` field is indexed only when it exists in the document (sparse).
 - The `name` field must be at least 3 characters long.
 - The `age` field must be non-negative.
+- The `points` field must be non-negative and a multiple of 5.
+- The `internal_tag` field is indexed but hidden from query planning, useful for internal/system metadata. 
 - The `active` field defaults to `false`.
 
 ---

--- a/oximod/tests/index.rs
+++ b/oximod/tests/index.rs
@@ -1,8 +1,12 @@
-use mongodb::bson::{ DateTime, oid::ObjectId, doc };
+use mongodb::{
+    bson::{ doc, oid::ObjectId, DateTime },
+    options::{ IndexVersion, TextIndexVersion },
+};
 use oximod::Model;
 use testresult::TestResult;
 use serde::{ Deserialize, Serialize };
 use std::{ thread::sleep, time::Duration };
+use futures_util::TryStreamExt;
 
 mod common;
 use common::init;
@@ -76,6 +80,91 @@ async fn ttl_index_removes_expired_documents() -> TestResult {
 
     let remaining = Session::find(doc! {}).await?;
     assert_eq!(remaining.len(), 0, "Expected document to be expired and deleted");
+
+    Ok(())
+}
+
+// Run test: cargo nextest run index_version_is_applied_correctly
+#[tokio::test]
+async fn index_version_is_applied_correctly() -> TestResult {
+    init().await;
+
+    #[derive(Model, Serialize, Deserialize)]
+    #[db("test")]
+    #[collection("version_index_test")]
+    pub struct VersionedIndex {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[index(version = 2, name = "v2_idx")]
+        data: String,
+    }
+
+    VersionedIndex::clear().await?;
+
+    let item = VersionedIndex::default().data("hello".to_string());
+    item.save().await?;
+
+    // Confirm the index is created with version 2
+    let mut cursor = VersionedIndex::get_collection()
+        .expect("Failed to get collection")
+        .list_indexes().await?;
+
+    let mut found = false;
+
+    while let Some(index) = cursor.try_next().await? {
+        if let Some(opts) = index.options {
+            if opts.name.as_deref() == Some("v2_idx") {
+                if let Some(IndexVersion::V2) = opts.version {
+                    found = true;
+                }
+            }
+        }
+    }
+
+    assert!(found, "Expected index with name 'v2_idx'");
+
+    Ok(())
+}
+
+// Run test: cargo nextest run text_index_version_is_applied_correctly
+#[tokio::test]
+async fn text_index_version_is_applied_correctly() -> TestResult {
+    init().await;
+
+    #[derive(Model, Serialize, Deserialize)]
+    #[db("test")]
+    #[collection("text_index_version_is_applied_correctly")]
+    pub struct TestModel {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[index(text_index_version = 2, name = "text_v2_idx")]
+        data: String,
+    }
+
+    TestModel::clear().await?;
+
+    let item = TestModel::default().data("hello".to_string());
+    item.save().await?;
+
+    let mut cursor = TestModel::get_collection()
+        .expect("Failed to get collection")
+        .list_indexes().await?;
+
+    let mut found = false;
+
+    while let Some(index) = cursor.try_next().await? {
+        if let Some(opts) = index.options {
+            if opts.name.as_deref() == Some("text_v2_idx") {
+                if let Some(TextIndexVersion::V2) = opts.text_index_version {
+                    found = true;
+                }
+            }
+        }
+    }
+
+    assert!(found, "Expected index with name 'text_v2_idx'");
 
     Ok(())
 }

--- a/oximod/tests/index.rs
+++ b/oximod/tests/index.rs
@@ -168,3 +168,42 @@ async fn text_index_version_is_applied_correctly() -> TestResult {
 
     Ok(())
 }
+
+// Run test: cargo nextest run hidden_index_is_applied_correctly
+#[tokio::test]
+async fn hidden_index_is_applied_correctly() -> TestResult {
+    init().await;
+
+    #[derive(Model, Serialize, Deserialize)]
+    #[db("test")]
+    #[collection("hidden_index_test")]
+    struct HiddenTest {
+        #[index(hidden, name = "hidden_idx")]
+        secret: String,
+    }
+
+    HiddenTest::clear().await?;
+
+    let doc = HiddenTest::default().secret("classified".to_string());
+    doc.save().await?;
+
+    let mut cursor = HiddenTest::get_collection()
+        .expect("failed to get collection")
+        .list_indexes().await?;
+
+    let mut found = false;
+
+    while let Some(index) = cursor.try_next().await? {
+        if let Some(name) = index.options.as_ref().and_then(|opts| opts.name.as_ref()) {
+            if name == "hidden_idx" {
+                let hidden = index.options.as_ref().and_then(|opts| opts.hidden);
+                assert_eq!(hidden, Some(true));
+                found = true;
+                break;
+            }
+        }
+    }
+
+    assert!(found, "Expected index 'hidden_idx' not found");
+    Ok(())
+}

--- a/oximod/tests/validate_multiple_of.rs
+++ b/oximod/tests/validate_multiple_of.rs
@@ -1,0 +1,44 @@
+mod common;
+
+use common::init;
+use mongodb::bson::oid::ObjectId;
+use oximod::Model;
+use serde::{ Deserialize, Serialize };
+use testresult::TestResult;
+
+#[derive(Model, Serialize, Deserialize, Debug)]
+#[db("test")]
+#[collection("validate_multiple_of")]
+pub struct Product {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    _id: Option<ObjectId>,
+
+    #[validate(multiple_of = 5)]
+    quantity: u64,
+}
+
+// Run test: cargo nextest run test_multiple_of_passes
+#[tokio::test]
+async fn test_multiple_of_passes() -> TestResult {
+    init().await;
+    Product::clear().await?;
+
+    let product = Product::default().quantity(10); // ✅ divisible by 5
+    let result = product.save().await?;
+    assert_ne!(result, ObjectId::default());
+    Ok(())
+}
+
+// Run test: cargo nextest run test_multiple_of_fails
+#[tokio::test]
+async fn test_multiple_of_fails() -> TestResult {
+    init().await;
+    Product::clear().await?;
+
+    let product = Product::default().quantity(7); // ❌ not divisible by 5
+    let result = product.save().await;
+
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("must be a multiple of"));
+    Ok(())
+}

--- a/oximod/tests/validate_string.rs
+++ b/oximod/tests/validate_string.rs
@@ -1,0 +1,107 @@
+mod common;
+
+use common::init;
+use mongodb::bson::oid::ObjectId;
+use oximod::Model;
+use serde::{Deserialize, Serialize};
+use testresult::TestResult;
+
+#[derive(Model, Serialize, Deserialize, Debug)]
+#[db("test")]
+#[collection("validate_string_tests")]
+pub struct StringValidation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    _id: Option<ObjectId>,
+
+    #[validate(starts_with = "abc", ends_with = "xyz", includes = "middle", alphanumeric, non_empty)]
+    value: Option<String>,
+}
+
+// Run test: cargo nextest run test_valid_string_passes
+#[tokio::test]
+async fn test_valid_string_passes() -> TestResult {
+    init().await;
+    StringValidation::clear().await?;
+
+    let doc = StringValidation::default()
+        .value("abcmiddlexyz".to_string()); // ✅ all conditions met
+
+    let result = doc.save().await?;
+    assert_ne!(result, ObjectId::default());
+    Ok(())
+}
+
+// Run test: cargo nextest run test_starts_with_fails
+#[tokio::test]
+async fn test_starts_with_fails() -> TestResult {
+    init().await;
+    StringValidation::clear().await?;
+
+    let doc = StringValidation::default()
+        .value("wrongmiddlexyz".to_string()); // ❌ does not start with "abc"
+
+    let result = doc.save().await;
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("must start with"));
+    Ok(())
+}
+
+// Run test: cargo nextest run test_ends_with_fails
+#[tokio::test]
+async fn test_ends_with_fails() -> TestResult {
+    init().await;
+    StringValidation::clear().await?;
+
+    let doc = StringValidation::default()
+        .value("abcmiddlewrong".to_string()); // ❌ does not end with "xyz"
+
+    let result = doc.save().await;
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("must end with"));
+    Ok(())
+}
+
+// Run test: cargo nextest run test_includes_fails
+#[tokio::test]
+async fn test_includes_fails() -> TestResult {
+    init().await;
+    StringValidation::clear().await?;
+
+    let doc = StringValidation::default()
+        .value("abcnomatchxyz".to_string()); // ❌ does not include "middle"
+
+    let result = doc.save().await;
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("must include"));
+    Ok(())
+}
+
+// Run test: cargo nextest run test_alphanumeric_fails
+#[tokio::test]
+async fn test_alphanumeric_fails() -> TestResult {
+    init().await;
+    StringValidation::clear().await?;
+
+    let doc = StringValidation::default()
+        .value("abcmiddle!xyz".to_string()); // ❌ contains "!"
+
+    let result = doc.save().await;
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("must contain only alphanumeric"));
+    Ok(())
+}
+
+// Run test: cargo nextest run test_empty_string_fails
+#[tokio::test]
+async fn test_empty_string_fails() -> TestResult {
+    init().await;
+    StringValidation::clear().await?;
+
+    let doc = StringValidation::default()
+        .value("   ".to_string()); // ❌ empty string after trim
+
+    let result = doc.save().await;
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("must be non-empty"));
+    Ok(())
+}

--- a/oximod_macros/Cargo.toml
+++ b/oximod_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oximod_macros"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["Arshia Eskandari <email@arshiaeskandari.com>"]
 description = "Procedural macros for the OxiMod MongoDB ODM."

--- a/oximod_macros/src/index.rs
+++ b/oximod_macros/src/index.rs
@@ -44,6 +44,11 @@ use syn::{ Attribute, Lit };
 ///   - Supported values include `1`, `2`, and `3`, or `Custom(N)`.
 ///   - Use this to explicitly control MongoDB's text indexing behavior.
 ///
+/// - `hidden`: (Optional) Whether the index is hidden from the query planner.
+///   - If `true`, the index exists but will not be used by the query planner unless explicitly hinted.
+///   - Useful for testing or safely rolling out new indexes.
+///   - Default: `false`
+/// 
 /// # Example
 ///
 /// ```rust
@@ -68,6 +73,7 @@ pub struct IndexArgs {
     pub expire_after_secs: Option<i32>,
     pub version: Option<u32>,
     pub text_index_version: Option<u32>,
+    pub hidden: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -140,6 +146,8 @@ pub fn parse_index_args(attr: &Attribute, field_name: String) -> syn::Result<Ind
                     ));
                 }
                 args.text_index_version = Some(text_index_version); 
+            } else if meta.path.is_ident("hidden") {
+                args.hidden = Some(true);
             }
 
             Ok(())
@@ -202,6 +210,11 @@ pub fn generate_index_model_tokens(index_def: &IndexDefinition) -> TokenStream {
         None => quote! { None },
     };
 
+    let hidden = match index_def.args.hidden {
+        Some(val) => quote! { Some(#val) },
+        None => quote! { None },
+    };
+
     quote! {
         ::oximod::_mongodb::IndexModel::builder()
             .keys(::oximod::_mongodb::bson::doc! { #key_entry })
@@ -214,6 +227,7 @@ pub fn generate_index_model_tokens(index_def: &IndexDefinition) -> TokenStream {
                     .expire_after(#expire_after_secs)
                     .version(#version)
                     .text_index_version(#text_index_version)
+                    .hidden(#hidden)
                     .build()
             )
             .build()

--- a/oximod_macros/src/index.rs
+++ b/oximod_macros/src/index.rs
@@ -34,6 +34,16 @@ use syn::{ Attribute, Lit };
 ///   - If set, documents will be automatically deleted after the specified number of seconds.
 ///   - If not provided, documents will not automatically expire.
 ///
+/// - `version`: (Optional) The version of the index structure to use.
+///   - Applies to standard indexes (e.g., B-tree).
+///   - Most common values are `1` or `2`; `Custom(N)` can also be specified.
+///   - Only meaningful for certain index types; may be ignored for default scalar indexes.
+///
+/// - `text_index_version`: (Optional) The version of the text index structure to use.
+///   - Applies only to `text` indexes.
+///   - Supported values include `1`, `2`, and `3`, or `Custom(N)`.
+///   - Use this to explicitly control MongoDB's text indexing behavior.
+///
 /// # Example
 ///
 /// ```rust
@@ -45,6 +55,9 @@ use syn::{ Attribute, Lit };
 /// - These fields **can be combined freely** — for example, you can have an index that is both `unique` and `sparse`.
 /// - MongoDB allows combining `unique`, `sparse`, and `background`.
 /// - The `name` field is just metadata and does not conflict with others.
+/// - Version fields are **optional** and typically only needed for compatibility or performance tuning.
+/// - `text_index_version` is only applicable if the index type is explicitly `text`.
+/// - ⚠️ If both `order` and `text_index_version` are provided, `order` will be ignored. 
 ///
 pub struct IndexArgs {
     pub unique: Option<bool>,
@@ -53,6 +66,8 @@ pub struct IndexArgs {
     pub background: Option<bool>,
     pub order: Option<i32>,
     pub expire_after_secs: Option<i32>,
+    pub version: Option<u32>,
+    pub text_index_version: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -60,6 +75,18 @@ pub struct IndexDefinition {
     pub field_name: String,
     pub args: IndexArgs,
 }
+
+macro_rules! parse_lit_to_number {
+    ($lit:expr, $ty:ty) => {{
+        match $lit {
+            syn::Lit::Int(lit_int) => lit_int.base10_parse::<$ty>(),
+            syn::Lit::Str(lit_str) => lit_str.value().parse::<$ty>()
+                .map_err(|e| syn::Error::new(lit_str.span(), format!("could not parse number: {}", e))),
+            other => Err(syn::Error::new(other.span(), "expected integer or string literal")),
+        }
+    }};
+}
+
 
 pub fn parse_index_args(attr: &Attribute, field_name: String) -> syn::Result<IndexDefinition> {
     let mut args = IndexArgs::default();
@@ -79,27 +106,7 @@ pub fn parse_index_args(attr: &Attribute, field_name: String) -> syn::Result<Ind
                 }
             } else if meta.path.is_ident("order") {
                 let lit: Lit = meta.value()?.parse()?;
-                let order_val = match lit {
-                    Lit::Int(lit_int) => lit_int.base10_parse::<i32>()?,
-                    Lit::Str(lit_str) =>
-                        lit_str
-                            .value()
-                            .parse::<i32>()
-                            .map_err(|e|
-                                syn::Error::new(
-                                    lit_str.span(),
-                                    format!("could not parse order: {}", e)
-                                )
-                            )?,
-                    other => {
-                        return Err(
-                            syn::Error::new(
-                                other.span(),
-                                "expected integer literal or string literal for `order`"
-                            )
-                        );
-                    }
-                };
+                let order_val: i32 = parse_lit_to_number!(lit, i32)?;
                 args.order = Some(order_val);
             } else if meta.path.is_ident("expire_after_secs") {
                 let lit: Lit = meta.value()?.parse()?;
@@ -113,7 +120,28 @@ pub fn parse_index_args(attr: &Attribute, field_name: String) -> syn::Result<Ind
                         )
                     );
                 }
+            } else if meta.path.is_ident("version") {
+                let lit: Lit = meta.value()?.parse()?;
+                let version = parse_lit_to_number!(&lit, u32)?;
+                if version == 0 {
+                    return Err(syn::Error::new(
+                        lit.span(),
+                        "`text_index_version` must be >= 1",
+                    ));
+                }
+                args.version = Some(version);
+            } else if meta.path.is_ident("text_index_version") {
+                let lit: Lit = meta.value()?.parse()?;
+                let text_index_version = parse_lit_to_number!(&lit, u32)?;
+                if text_index_version == 0 {
+                    return Err(syn::Error::new(
+                        lit.span(),
+                        "`text_index_version` must be >= 1",
+                    ));
+                }
+                args.text_index_version = Some(text_index_version); 
             }
+
             Ok(())
         })?;
     }
@@ -123,7 +151,16 @@ pub fn parse_index_args(attr: &Attribute, field_name: String) -> syn::Result<Ind
 
 pub fn generate_index_model_tokens(index_def: &IndexDefinition) -> TokenStream {
     let field = &index_def.field_name;
-    let order = index_def.args.order.unwrap_or(1);
+    let is_text = index_def.args.text_index_version.is_some();
+    
+    let key_entry = if is_text {
+        // for text indexes, the value must be the string "text"
+        quote! { #field: "text" }
+    } else {
+        // for numeric indexes, use the order
+        let order = index_def.args.order.unwrap_or(1);
+        quote! { #field: #order }
+    };
 
     let unique = match index_def.args.unique {
         Some(val) => quote! { Some(#val) },
@@ -150,9 +187,24 @@ pub fn generate_index_model_tokens(index_def: &IndexDefinition) -> TokenStream {
         None => quote! { None },
     };
 
+    let version = match index_def.args.version {
+        Some(v) if v == 1 => quote! { Some(::oximod::_mongodb::options::IndexVersion::V1) },
+        Some(v) if v == 2 => quote! { Some(::oximod::_mongodb::options::IndexVersion::V2) },
+        Some(v) => quote! { Some(::oximod::_mongodb::options::IndexVersion::Custom(#v)) },
+        None => quote! { None },
+    };
+    
+    let text_index_version = match index_def.args.text_index_version {
+        Some(v) if v == 1 => quote! { Some(::oximod::_mongodb::options::TextIndexVersion::V1) },
+        Some(v) if v == 2 => quote! { Some(::oximod::_mongodb::options::TextIndexVersion::V2) },
+        Some(v) if v == 3 => quote! { Some(::oximod::_mongodb::options::TextIndexVersion::V3) },
+        Some(v) => quote! { Some(::oximod::_mongodb::options::TextIndexVersion::Custom(#v)) },
+        None => quote! { None },
+    };
+
     quote! {
         ::oximod::_mongodb::IndexModel::builder()
-            .keys(::oximod::_mongodb::bson::doc! { #field: #order })
+            .keys(::oximod::_mongodb::bson::doc! { #key_entry })
             .options(
                 ::oximod::_mongodb::options::IndexOptions::builder()
                     .unique(#unique)
@@ -160,6 +212,8 @@ pub fn generate_index_model_tokens(index_def: &IndexDefinition) -> TokenStream {
                     .background(#background)
                     .name(#name)
                     .expire_after(#expire_after_secs)
+                    .version(#version)
+                    .text_index_version(#text_index_version)
                     .build()
             )
             .build()

--- a/oximod_macros/src/validate.rs
+++ b/oximod_macros/src/validate.rs
@@ -54,6 +54,26 @@ use syn::{ Attribute, Lit };
 ///   - If provided, the field’s numeric value must be <= this value.
 ///   - Default: no maximum‐value constraint.
 ///
+/// - `starts_with`: (Optional) A required string prefix the field value must start with.
+///   - If provided, the field value must begin with this substring.
+///   - Default: not enforced.
+///
+/// - `ends_with`: (Optional) A required string suffix the field value must end with.
+///   - If provided, the field value must end with this substring.
+///   - Default: not enforced.
+///
+/// - `includes`: (Optional) A required substring the field value must contain.
+///   - If provided, the field must contain this substring somewhere.
+///   - Default: not enforced.
+///
+/// - `alphanumeric`: (Optional) Whether the field must only contain letters and digits.
+///   - If `true`, the field value must match `/^[a-zA-Z0-9]+$/`.
+///   - Default: `false` (no alphanumeric constraint).
+///
+/// - `multiple_of`: (Optional) Whether the field value must be a multiple of the given integer.
+///   - If provided, the field value must be evenly divisible by this number.
+///   - Default: not enforced. 
+/// 
 /// # Example
 ///
 /// ```rust
@@ -87,6 +107,11 @@ pub struct ValidateArgs {
     pub non_negative: Option<bool>,
     pub min: Option<i64>,
     pub max: Option<i64>,
+    pub starts_with: Option<String>,
+    pub ends_with: Option<String>,
+    pub includes: Option<String>,
+    pub alphanumeric: Option<bool>,
+    pub multiple_of: Option<u64>,
 }
 
 pub struct ValidateDefinition {
@@ -171,6 +196,46 @@ pub fn parse_validate_args(
                 } else {
                     return Err(syn::Error::new(lit.span(), "expected integer literal for `max`"));
                 }
+            } else if meta.path.is_ident("starts_with") {
+                let lit = meta.value()?.parse()?;
+                if let Lit::Str(lit_str) = lit {
+                    args.starts_with = Some(lit_str.value());
+                } else {
+                    return Err(syn::Error::new(lit.span(), "expected string literal for `starts_with`"));
+                }
+            } else if meta.path.is_ident("ends_with") {
+                let lit = meta.value()?.parse()?;
+                if let Lit::Str(lit_str) = lit {
+                    args.ends_with = Some(lit_str.value());
+                } else {
+                    return Err(syn::Error::new(lit.span(), "expected string literal for `ends_with`"));
+                }
+            } else if meta.path.is_ident("includes") {
+                let lit = meta.value()?.parse()?;
+                if let Lit::Str(lit_str) = lit {
+                    args.includes = Some(lit_str.value());
+                } else {
+                    return Err(syn::Error::new(lit.span(), "expected string literal for `includes`"));
+                }
+            } else if meta.path.is_ident("alphanumeric") {
+                args.alphanumeric = Some(true);
+            } else if meta.path.is_ident("multiple_of") {
+                let lit = meta.value()?.parse()?;
+                if let Lit::Int(lit_int) = &lit {
+                    let val = lit_int.base10_parse::<u64>()?;
+                    if val == 0 {
+                        return Err(syn::Error::new(
+                            lit.span(),
+                            "`multiple_of` must be greater than 0"
+                        ));
+                    }
+                    args.multiple_of = Some(val);
+                } else {
+                    return Err(syn::Error::new(
+                        lit.span(),
+                        "expected integer literal for `multiple_of`"
+                    ));
+                }
             } else {
                 return Err(meta.error("unknown attribute key"));
             }
@@ -197,6 +262,11 @@ pub fn generate_validate_model_tokens(validate_def: &ValidateDefinition) -> Vec<
         non_negative,
         min,
         max,
+        starts_with,
+        ends_with,
+        includes,
+        alphanumeric,
+        multiple_of,
     } = &validate_def.args;
 
     let mut checks = vec![];
@@ -442,6 +512,84 @@ pub fn generate_validate_model_tokens(validate_def: &ValidateDefinition) -> Vec<
         }
         );
     }
+
+    if let Some(start) = starts_with {
+        checks.push(
+            quote! {
+            if let Some(ref val) = self.#field_ident {
+                if !val.starts_with(#start) {
+                    return Err(::oximod::_attach_printables!(
+                        ::oximod::_error::oximod_error::OximodError::ValidationError(
+                            format!("Field '{}' must start with '{}'", stringify!(#field_ident), #start)
+                        ),
+                        concat!("Ensure '", stringify!(#field_ident), "' starts with '", #start, "'.")
+                    ));
+                }
+            }
+        });
+    }
+    
+    if let Some(end) = ends_with {
+        checks.push(
+            quote! {
+            if let Some(ref val) = self.#field_ident {
+                if !val.ends_with(#end) {
+                    return Err(::oximod::_attach_printables!(
+                        ::oximod::_error::oximod_error::OximodError::ValidationError(
+                            format!("Field '{}' must end with '{}'", stringify!(#field_ident), #end)
+                        ),
+                        concat!("Ensure '", stringify!(#field_ident), "' ends with '", #end, "'.")
+                    ));
+                }
+            }
+        });
+    }
+    
+    if let Some(substr) = includes {
+        checks.push(
+            quote! {
+            if let Some(ref val) = self.#field_ident {
+                if !val.contains(#substr) {
+                    return Err(::oximod::_attach_printables!(
+                        ::oximod::_error::oximod_error::OximodError::ValidationError(
+                            format!("Field '{}' must include '{}'", stringify!(#field_ident), #substr)
+                        ),
+                        concat!("Ensure '", stringify!(#field_ident), "' includes '", #substr, "'.")
+                    ));
+                }
+            }
+        });
+    }
+    
+    if let Some(true) = alphanumeric {
+        checks.push(
+            quote! {
+            if let Some(ref val) = self.#field_ident {
+                if !val.chars().all(|c| c.is_alphanumeric()) {
+                    return Err(::oximod::_attach_printables!(
+                        ::oximod::_error::oximod_error::OximodError::ValidationError(
+                            format!("Field '{}' must contain only alphanumeric characters", stringify!(#field_ident))
+                        ),
+                        concat!("Ensure '", stringify!(#field_ident), "' has only letters and numbers.")
+                    ));
+                }
+            }
+        });
+    }
+    
+    if let Some(multiple) = multiple_of {
+        checks.push(
+            quote! {
+            if self.#field_ident % #multiple != 0 {
+                return Err(::oximod::_attach_printables!(
+                    ::oximod::_error::oximod_error::OximodError::ValidationError(
+                        format!("Field '{}' must be a multiple of {}", stringify!(#field_ident), #multiple)
+                    ),
+                    concat!("Ensure '", stringify!(#field_ident), "' is divisible by ", #multiple, ".")
+                ));
+            }
+        });
+    }    
 
     checks
 }


### PR DESCRIPTION
## Description

This pull request closes #12 and introduces several enhancements to the OxiMod validation and indexing system.

### ✅ New Field Validators

Five new `#[validate(...)]` options are now supported, improving control over string and numeric fields:

- `starts_with = "..."`: Ensures the string starts with the given substring.
- `ends_with = "..."`: Ensures the string ends with the given substring.
- `includes = "..."`: Ensures the string includes the given substring.
- `alphanumeric`: Ensures the string contains only alphanumeric characters (letters and digits).
- `multiple_of = N`: Ensures the numeric field is a multiple of `N`. (Must be > 0)

All new validators are fully integrated into the `generate_validate_model_tokens` logic and have been thoroughly tested with both positive and negative test cases.

### 🆕 Index Options

Additionally, this PR introduces support for **three new `#[index(...)]` options**:

- `version = N`: Specifies the index version.
- `text_index_version = N`: Specifies the version of the text index.
- `hidden`: Makes the index invisible to the query planner.

These index options provide better compatibility with MongoDB’s index engine behavior and support forward-looking schema design.

Closes #12 
