### PR TITLE
fixed tests

### DIFF
--- a/oximod/tests/aggregate.rs
+++ b/oximod/tests/aggregate.rs
@@ -14,7 +14,7 @@ async fn aggregates_documents_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("aggregate_test")]
+    #[collection("logs_for_aggregates_documents_correctly")]
     pub struct LogEntry {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/builder_api.rs
+++ b/oximod/tests/builder_api.rs
@@ -6,21 +6,20 @@ use oximod::Model;
 use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
-/// A simple model used to test the `new`, `default`, and builder APIs.
-#[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
-#[db("test")]
-#[collection("builder_tests")]
-pub struct User {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-    name: String,
-    age: i32,
-    active: bool,
-}
-
 // Run test: cargo nextest run new_and_default_are_equivalent
 #[tokio::test]
 async fn new_and_default_are_equivalent() -> TestResult {
+    #[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
+    #[db("test")]
+    #[collection("builder_new_default_equivalent")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+        name: String,
+        age: i32,
+        active: bool,
+    }
+
     let user_new = User::new();
     let user_default = User::default();
 
@@ -31,6 +30,17 @@ async fn new_and_default_are_equivalent() -> TestResult {
 // Run test: cargo nextest run builder_sets_all_fields
 #[tokio::test]
 async fn builder_sets_all_fields() -> TestResult {
+    #[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
+    #[db("test")]
+    #[collection("builder_sets_all_fields")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+        name: String,
+        age: i32,
+        active: bool,
+    }
+
     let id = ObjectId::new();
     let user = User::default().id(id.clone()).name("User1".to_string()).age(30).active(true);
 
@@ -45,9 +55,19 @@ async fn builder_sets_all_fields() -> TestResult {
 // Run test: cargo nextest run builder_partial_fields_default_rest
 #[tokio::test]
 async fn builder_partial_fields_default_rest() -> TestResult {
+    #[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
+    #[db("test")]
+    #[collection("builder_partial_fields")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+        name: String,
+        age: i32,
+        active: bool,
+    }
+
     let user = User::default().name("User1".to_string());
 
-    // name should be set, rest should be their respective defaults
     assert_eq!(user.name, "User1");
     assert_eq!(user.age, 0);
     assert_eq!(user.active, false);
@@ -60,6 +80,18 @@ async fn builder_partial_fields_default_rest() -> TestResult {
 #[tokio::test]
 async fn builder_and_save_works_end_to_end() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
+    #[db("test")]
+    #[collection("builder_save_end_to_end")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+        name: String,
+        age: i32,
+        active: bool,
+    }
+
     User::clear().await?;
 
     let saved_id = User::default().name("User1".to_string()).age(42).active(true).save().await?;
@@ -84,7 +116,7 @@ async fn builder_using_custom_document_id_setter() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug, PartialEq)]
     #[db("test")]
-    #[collection("builder_tests")]
+    #[collection("builder_custom_id_setter")]
     #[document_id_setter_ident("my_custom_id_setter")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -98,7 +130,7 @@ async fn builder_using_custom_document_id_setter() -> TestResult {
     User::clear().await?;
 
     let saved_id = User::default()
-        .my_custom_id_setter(ObjectId::new()) // this provides maximum flexibility with field names
+        .my_custom_id_setter(ObjectId::new())
         .id("3894HR934HR00NJ23R324R".to_string())
         .name("User1".to_string())
         .age(42)

--- a/oximod/tests/clear.rs
+++ b/oximod/tests/clear.rs
@@ -13,7 +13,7 @@ async fn clears_collection_successfully() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("clear")]
+    #[collection("clear_test_clears_collection_successfully")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/count.rs
+++ b/oximod/tests/count.rs
@@ -13,7 +13,7 @@ async fn counts_matching_documents_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("count")]
+    #[collection("count_test_counts_matching_documents_correctly")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/default.rs
+++ b/oximod/tests/default.rs
@@ -13,7 +13,7 @@ async fn saves_with_default_string_and_number() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("defaults_str_num")]
+    #[collection("defaults_str_num_saves_with_default")]
     pub struct Thing {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -27,13 +27,10 @@ async fn saves_with_default_string_and_number() -> TestResult {
 
     Thing::clear().await?;
 
-    // We don't call `.name(...)` or `.count(...)` so defaults should apply:
     let thing = Thing::default();
     let id = thing.save().await?;
 
-    // Fetch raw document to inspect defaults:
-    let doc = Thing::find_one(doc! { "_id": id.clone() }).await?
-        .unwrap();
+    let doc = Thing::find_one(doc! { "_id": id.clone() }).await?.unwrap();
 
     assert_eq!(doc.name, "Anonymous");
     assert_eq!(doc.count, 0);
@@ -48,7 +45,7 @@ async fn override_default_values() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("defaults_override")]
+    #[collection("defaults_override_explicitly")]
     pub struct Record {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -62,7 +59,6 @@ async fn override_default_values() -> TestResult {
 
     Record::clear().await?;
 
-    // Override both defaults via fluent API:
     let rec = Record::default().user("Alice".to_string()).retries(5);
     let id = rec.save().await?;
 
@@ -86,7 +82,7 @@ async fn enum_default_and_override() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("defaults_enum")]
+    #[collection("defaults_enum_status_test")]
     pub struct Task {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -99,14 +95,12 @@ async fn enum_default_and_override() -> TestResult {
 
     Task::clear().await?;
 
-    // Without overriding, status == Pending
     let t1 = Task::default().description("T1".into());
     let id1 = t1.save().await?;
     let got1 = Task::find_by_id(id1).await?.unwrap();
     assert_eq!(got1.status, Status::Pending);
     assert_eq!(got1.description, "T1");
 
-    // Override to Complete
     let t2 = Task::default().status(Status::Complete).description("T2".into());
     let id2 = t2.save().await?;
     let got2 = Task::find_by_id(id2).await?.unwrap();

--- a/oximod/tests/delete.rs
+++ b/oximod/tests/delete.rs
@@ -13,7 +13,7 @@ async fn deletes_multiple_matching_documents() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("delete")]
+    #[collection("delete_test_deletes_multiple_matching_documents")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/delete_by_id.rs
+++ b/oximod/tests/delete_by_id.rs
@@ -13,7 +13,7 @@ async fn deletes_document_by_id_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("delete_by_id")]
+    #[collection("delete_by_id_test_deletes_document_by_id_correctly")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/delete_one.rs
+++ b/oximod/tests/delete_one.rs
@@ -13,7 +13,7 @@ async fn deletes_first_matching_document_only() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("delete_one")]
+    #[collection("delete_one_test_deletes_first_matching_document_only")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/exists.rs
+++ b/oximod/tests/exists.rs
@@ -13,7 +13,7 @@ async fn checks_existence_of_matching_document() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("exists")]
+    #[collection("exists_test_checks_existence_of_matching_document")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -25,7 +25,6 @@ async fn checks_existence_of_matching_document() -> TestResult {
     User::clear().await?;
 
     let user = User::default().name("User1".to_string()).age(27).active(true);
-
     user.save().await?;
 
     let exists = User::exists(doc! { "name": "User1" }).await?;

--- a/oximod/tests/find.rs
+++ b/oximod/tests/find.rs
@@ -13,7 +13,7 @@ async fn finds_multiple_matching_documents() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("find")]
+    #[collection("find_test_finds_multiple_matching_documents")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/find_by_id.rs
+++ b/oximod/tests/find_by_id.rs
@@ -13,7 +13,7 @@ async fn finds_document_by_id_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("find_by_id")]
+    #[collection("find_by_id_test_finds_document_by_id_correctly")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/find_one.rs
+++ b/oximod/tests/find_one.rs
@@ -13,7 +13,7 @@ async fn finds_first_matching_document_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("find_one")]
+    #[collection("find_one_test_finds_first_matching_document_correctly")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/get_collection.rs
+++ b/oximod/tests/get_collection.rs
@@ -13,7 +13,7 @@ async fn uses_get_collection_and_manual_indexing() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize, Debug)]
     #[db("test")]
-    #[collection("manual_index_test")]
+    #[collection("manual_index_test_uses_get_collection_and_manual_indexing")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,

--- a/oximod/tests/index.rs
+++ b/oximod/tests/index.rs
@@ -12,13 +12,13 @@ mod common;
 use common::init;
 
 // Run test: cargo nextest run creates_indexes_correctly
-#[tokio::test] // Might throw `expected Expr rust-analyzer` so disable "macro-error"
+#[tokio::test]
 async fn creates_indexes_correctly() -> TestResult {
     init().await;
 
     #[derive(Model, Serialize, Deserialize)]
     #[db("test")]
-    #[collection("index_test")]
+    #[collection("index_test_creates_indexes_correctly")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -43,7 +43,6 @@ async fn creates_indexes_correctly() -> TestResult {
         .created_at(DateTime::now())
         .active(true);
 
-    // This will trigger create_indexes() inside save
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());
 
@@ -57,7 +56,7 @@ async fn ttl_index_removes_expired_documents() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize)]
     #[db("test")]
-    #[collection("ttl_test")]
+    #[collection("ttl_test_removes_expired_documents")]
     pub struct Session {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -68,14 +67,12 @@ async fn ttl_index_removes_expired_documents() -> TestResult {
 
     Session::clear().await?;
 
-    // Insert a document with a created_at timestamp in the past
     let expired_session = Session::default().created_at(
         DateTime::from_millis(DateTime::now().timestamp_millis() - 10_000)
     );
 
     expired_session.save().await?;
 
-    // Give MongoDB TTL monitor enough time to delete the expired document
     sleep(Duration::from_secs(65));
 
     let remaining = Session::find(doc! {}).await?;
@@ -91,7 +88,7 @@ async fn index_version_is_applied_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize)]
     #[db("test")]
-    #[collection("version_index_test")]
+    #[collection("index_version_is_applied_correctly")]
     pub struct VersionedIndex {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -105,11 +102,7 @@ async fn index_version_is_applied_correctly() -> TestResult {
     let item = VersionedIndex::default().data("hello".to_string());
     item.save().await?;
 
-    // Confirm the index is created with version 2
-    let mut cursor = VersionedIndex::get_collection()
-        .expect("Failed to get collection")
-        .list_indexes().await?;
-
+    let mut cursor = VersionedIndex::get_collection()?.list_indexes().await?;
     let mut found = false;
 
     while let Some(index) = cursor.try_next().await? {
@@ -148,10 +141,7 @@ async fn text_index_version_is_applied_correctly() -> TestResult {
     let item = TestModel::default().data("hello".to_string());
     item.save().await?;
 
-    let mut cursor = TestModel::get_collection()
-        .expect("Failed to get collection")
-        .list_indexes().await?;
-
+    let mut cursor = TestModel::get_collection()?.list_indexes().await?;
     let mut found = false;
 
     while let Some(index) = cursor.try_next().await? {
@@ -176,7 +166,7 @@ async fn hidden_index_is_applied_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize)]
     #[db("test")]
-    #[collection("hidden_index_test")]
+    #[collection("hidden_index_is_applied_correctly")]
     struct HiddenTest {
         #[index(hidden, name = "hidden_idx")]
         secret: String,
@@ -187,10 +177,7 @@ async fn hidden_index_is_applied_correctly() -> TestResult {
     let doc = HiddenTest::default().secret("classified".to_string());
     doc.save().await?;
 
-    let mut cursor = HiddenTest::get_collection()
-        .expect("failed to get collection")
-        .list_indexes().await?;
-
+    let mut cursor = HiddenTest::get_collection()?.list_indexes().await?;
     let mut found = false;
 
     while let Some(index) = cursor.try_next().await? {

--- a/oximod/tests/save.rs
+++ b/oximod/tests/save.rs
@@ -12,8 +12,8 @@ async fn saves_document_without_id_correctly() -> TestResult {
     init().await;
 
     #[derive(Model, Serialize, Deserialize)]
-    #[db("db_name")]
-    #[collection("collection_name")]
+    #[db("test")]
+    #[collection("save_without_id")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -25,7 +25,6 @@ async fn saves_document_without_id_correctly() -> TestResult {
     User::clear().await?;
 
     let user = User::default().name("User1".to_string()).age(25).active(true);
-
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());
 
@@ -39,7 +38,7 @@ async fn saves_document_with_id_correctly() -> TestResult {
 
     #[derive(Model, Serialize, Deserialize)]
     #[db("test")]
-    #[collection("save")]
+    #[collection("save_with_id")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
         _id: Option<ObjectId>,
@@ -52,7 +51,6 @@ async fn saves_document_with_id_correctly() -> TestResult {
 
     let id = ObjectId::new();
     let user = User::default().id(id.clone()).name("User1".to_string()).age(30).active(false);
-
     let result = user.save().await?;
     assert_eq!(result, id);
 

--- a/oximod/tests/update_by_id.rs
+++ b/oximod/tests/update_by_id.rs
@@ -12,7 +12,7 @@ async fn updates_document_by_id_correctly() -> TestResult {
     init().await;
 
     #[derive(Model, Serialize, Deserialize, Debug)]
-    #[db("ptest")]
+    #[db("test")]
     #[collection("update_by_id")]
     pub struct User {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -25,7 +25,11 @@ async fn updates_document_by_id_correctly() -> TestResult {
     User::clear().await?;
 
     let id = ObjectId::new();
-    let user = User::default().id(id.clone()).name("User1".to_string()).age(31).active(true);
+    let user = User::default()
+        .id(id.clone())
+        .name("User1".to_string())
+        .age(31)
+        .active(true);
 
     user.save().await?;
 

--- a/oximod/tests/validate_email.rs
+++ b/oximod/tests/validate_email.rs
@@ -13,27 +13,28 @@ pub enum Role {
     Guess,
 }
 
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_email")]
-pub struct User {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(min_length = 5, max_length = 10)]
-    name: String,
-
-    #[validate(email)]
-    email: Option<String>,
-
-    #[validate(required)]
-    role: Option<Role>,
-}
-
 // Run test: cargo nextest run test_missing_at_symbol
 #[tokio::test]
 async fn test_missing_at_symbol() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_email_missing_at")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()
@@ -51,6 +52,24 @@ async fn test_missing_at_symbol() -> TestResult {
 #[tokio::test]
 async fn test_missing_domain_dot() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_email_missing_dot")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()
@@ -68,6 +87,24 @@ async fn test_missing_domain_dot() -> TestResult {
 #[tokio::test]
 async fn test_valid_email() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_email_valid")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()

--- a/oximod/tests/validate_length.rs
+++ b/oximod/tests/validate_length.rs
@@ -13,27 +13,28 @@ pub enum Role {
     Guess,
 }
 
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_length")]
-pub struct User {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(min_length = 5, max_length = 10)]
-    name: String,
-
-    #[validate(email)]
-    email: Option<String>,
-
-    #[validate(required)]
-    role: Option<Role>,
-}
-
 // Run test: cargo nextest run test_min_length_violation
 #[tokio::test]
 async fn test_min_length_violation() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_length_min")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()
@@ -52,6 +53,24 @@ async fn test_min_length_violation() -> TestResult {
 #[tokio::test]
 async fn test_max_length_violation() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_length_max")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()
@@ -70,10 +89,28 @@ async fn test_max_length_violation() -> TestResult {
 #[tokio::test]
 async fn test_length_valid() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_length_valid")]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()
-        .name("ValidName".to_string()) // valid
+        .name("ValidName".to_string())
         .email("user@example.com".to_string())
         .role(Role::Admin);
 

--- a/oximod/tests/validate_min_and_max.rs
+++ b/oximod/tests/validate_min_and_max.rs
@@ -6,27 +6,28 @@ use oximod::Model;
 use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_min_and_max")]
-pub struct Book {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(min = 100)]
-    pages: i32,
-
-    #[validate(max = 100)]
-    price: i32,
-
-    #[validate(min = 1900, max = 2025)]
-    year: i32,
-}
-
 // Run test: cargo nextest run test_book_min_violation
 #[tokio::test]
 async fn test_book_min_violation() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_min_only")]
+    struct Book {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min = 100)]
+        pages: i32,
+
+        #[validate(max = 100)]
+        price: i32,
+
+        #[validate(min = 1900, max = 2025)]
+        year: i32,
+    }
+
     Book::clear().await?;
 
     let book = Book::default()
@@ -44,6 +45,24 @@ async fn test_book_min_violation() -> TestResult {
 #[tokio::test]
 async fn test_book_max_violation() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_max_only")]
+    struct Book {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min = 100)]
+        pages: i32,
+
+        #[validate(max = 100)]
+        price: i32,
+
+        #[validate(min = 1900, max = 2025)]
+        year: i32,
+    }
+
     Book::clear().await?;
 
     let book = Book::default()
@@ -61,6 +80,24 @@ async fn test_book_max_violation() -> TestResult {
 #[tokio::test]
 async fn test_book_valid() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_book_valid")]
+    struct Book {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min = 100)]
+        pages: i32,
+
+        #[validate(max = 100)]
+        price: i32,
+
+        #[validate(min = 1900, max = 2025)]
+        year: i32,
+    }
+
     Book::clear().await?;
 
     let book = Book::default().pages(120).price(90).year(2022);

--- a/oximod/tests/validate_multiple_of.rs
+++ b/oximod/tests/validate_multiple_of.rs
@@ -6,21 +6,22 @@ use oximod::Model;
 use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_multiple_of")]
-pub struct Product {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(multiple_of = 5)]
-    quantity: u64,
-}
-
 // Run test: cargo nextest run test_multiple_of_passes
 #[tokio::test]
 async fn test_multiple_of_passes() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_multiple_of_passes")]
+    struct Product {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(multiple_of = 5)]
+        quantity: u64,
+    }
+
     Product::clear().await?;
 
     let product = Product::default().quantity(10); // ✅ divisible by 5
@@ -33,6 +34,18 @@ async fn test_multiple_of_passes() -> TestResult {
 #[tokio::test]
 async fn test_multiple_of_fails() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_multiple_of_fails")]
+    struct Product {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(multiple_of = 5)]
+        quantity: u64,
+    }
+
     Product::clear().await?;
 
     let product = Product::default().quantity(7); // ❌ not divisible by 5

--- a/oximod/tests/validate_pattern.rs
+++ b/oximod/tests/validate_pattern.rs
@@ -6,33 +6,34 @@ use oximod::Model;
 use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
 
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_pattern")]
-pub struct Product {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(pattern = r"^SKU-\d{4}$")]
-    code: Option<String>,
-
-    #[validate(non_empty)]
-    name: Option<String>,
-
-    #[validate(positive)]
-    quantity: i32,
-
-    #[validate(negative)]
-    temperature: i32,
-
-    #[validate(non_negative)]
-    rating: i32,
-}
-
 // Run test: cargo nextest run test_invalid_pattern_format
 #[tokio::test]
 async fn test_invalid_pattern_format() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_pattern_invalid")]
+    struct Product {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(pattern = r"^SKU-\d{4}$")]
+        code: Option<String>,
+
+        #[validate(non_empty)]
+        name: Option<String>,
+
+        #[validate(positive)]
+        quantity: i32,
+
+        #[validate(negative)]
+        temperature: i32,
+
+        #[validate(non_negative)]
+        rating: i32,
+    }
+
     Product::clear().await?;
 
     let product = Product::default()
@@ -52,6 +53,30 @@ async fn test_invalid_pattern_format() -> TestResult {
 #[tokio::test]
 async fn test_valid_pattern_format() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_pattern_valid")]
+    struct Product {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(pattern = r"^SKU-\d{4}$")]
+        code: Option<String>,
+
+        #[validate(non_empty)]
+        name: Option<String>,
+
+        #[validate(positive)]
+        quantity: i32,
+
+        #[validate(negative)]
+        temperature: i32,
+
+        #[validate(non_negative)]
+        rating: i32,
+    }
+
     Product::clear().await?;
 
     let product = Product::default()

--- a/oximod/tests/validate_required_enum.rs
+++ b/oximod/tests/validate_required_enum.rs
@@ -13,27 +13,28 @@ pub enum Role {
     Guess,
 }
 
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_required_enum")]
-pub struct User {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(min_length = 5, max_length = 10)]
-    name: String,
-
-    #[validate(required, email)]
-    email: Option<String>,
-
-    #[validate(required)]
-    role: Option<Role>,
-}
-
 // Run test: cargo nextest run test_missing_required_email
 #[tokio::test]
 async fn test_missing_required_email() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_required_email_missing")]
+    struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(required, email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default().name("Valid".to_string()).role(Role::User); // ❌ missing email
@@ -48,6 +49,24 @@ async fn test_missing_required_email() -> TestResult {
 #[tokio::test]
 async fn test_missing_required_role() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_required_role_missing")]
+    struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(required, email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default().name("Valid".to_string()).email("user@example.com".to_string()); // ❌ missing role
@@ -62,12 +81,30 @@ async fn test_missing_required_role() -> TestResult {
 #[tokio::test]
 async fn test_valid_required_enum() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_required_valid")]
+    struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(min_length = 5, max_length = 10)]
+        name: String,
+
+        #[validate(required, email)]
+        email: Option<String>,
+
+        #[validate(required)]
+        role: Option<Role>,
+    }
+
     User::clear().await?;
 
     let user = User::default()
         .name("Valid".to_string())
         .email("user@example.com".to_string())
-        .role(Role::Admin); // ✅ allowed enum
+        .role(Role::Admin); // ✅ valid case
 
     let result = user.save().await?;
     assert_ne!(result, ObjectId::default());

--- a/oximod/tests/validate_string.rs
+++ b/oximod/tests/validate_string.rs
@@ -3,29 +3,34 @@ mod common;
 use common::init;
 use mongodb::bson::oid::ObjectId;
 use oximod::Model;
-use serde::{Deserialize, Serialize};
+use serde::{ Deserialize, Serialize };
 use testresult::TestResult;
-
-#[derive(Model, Serialize, Deserialize, Debug)]
-#[db("test")]
-#[collection("validate_string_tests")]
-pub struct StringValidation {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    _id: Option<ObjectId>,
-
-    #[validate(starts_with = "abc", ends_with = "xyz", includes = "middle", alphanumeric, non_empty)]
-    value: Option<String>,
-}
 
 // Run test: cargo nextest run test_valid_string_passes
 #[tokio::test]
 async fn test_valid_string_passes() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_string_valid")]
+    struct StringValidation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(
+            starts_with = "abc",
+            ends_with = "xyz",
+            includes = "middle",
+            alphanumeric,
+            non_empty
+        )]
+        value: Option<String>,
+    }
+
     StringValidation::clear().await?;
 
-    let doc = StringValidation::default()
-        .value("abcmiddlexyz".to_string()); // ✅ all conditions met
-
+    let doc = StringValidation::default().value("abcmiddlexyz".to_string());
     let result = doc.save().await?;
     assert_ne!(result, ObjectId::default());
     Ok(())
@@ -35,11 +40,21 @@ async fn test_valid_string_passes() -> TestResult {
 #[tokio::test]
 async fn test_starts_with_fails() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_starts_with_fail")]
+    struct StringValidation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(starts_with = "abc")]
+        value: Option<String>,
+    }
+
     StringValidation::clear().await?;
 
-    let doc = StringValidation::default()
-        .value("wrongmiddlexyz".to_string()); // ❌ does not start with "abc"
-
+    let doc = StringValidation::default().value("wrongmiddlexyz".to_string());
     let result = doc.save().await;
     assert!(result.is_err());
     assert!(format!("{:?}", result).contains("must start with"));
@@ -50,11 +65,21 @@ async fn test_starts_with_fails() -> TestResult {
 #[tokio::test]
 async fn test_ends_with_fails() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_ends_with_fail")]
+    struct StringValidation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(ends_with = "xyz")]
+        value: Option<String>,
+    }
+
     StringValidation::clear().await?;
 
-    let doc = StringValidation::default()
-        .value("abcmiddlewrong".to_string()); // ❌ does not end with "xyz"
-
+    let doc = StringValidation::default().value("abcmiddlewrong".to_string());
     let result = doc.save().await;
     assert!(result.is_err());
     assert!(format!("{:?}", result).contains("must end with"));
@@ -65,11 +90,21 @@ async fn test_ends_with_fails() -> TestResult {
 #[tokio::test]
 async fn test_includes_fails() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_includes_fail")]
+    struct StringValidation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(includes = "middle")]
+        value: Option<String>,
+    }
+
     StringValidation::clear().await?;
 
-    let doc = StringValidation::default()
-        .value("abcnomatchxyz".to_string()); // ❌ does not include "middle"
-
+    let doc = StringValidation::default().value("abcnomatchxyz".to_string());
     let result = doc.save().await;
     assert!(result.is_err());
     assert!(format!("{:?}", result).contains("must include"));
@@ -80,11 +115,21 @@ async fn test_includes_fails() -> TestResult {
 #[tokio::test]
 async fn test_alphanumeric_fails() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_alphanumeric_fail")]
+    struct StringValidation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(alphanumeric)]
+        value: Option<String>,
+    }
+
     StringValidation::clear().await?;
 
-    let doc = StringValidation::default()
-        .value("abcmiddle!xyz".to_string()); // ❌ contains "!"
-
+    let doc = StringValidation::default().value("abcmiddle!xyz".to_string());
     let result = doc.save().await;
     assert!(result.is_err());
     assert!(format!("{:?}", result).contains("must contain only alphanumeric"));
@@ -95,11 +140,21 @@ async fn test_alphanumeric_fails() -> TestResult {
 #[tokio::test]
 async fn test_empty_string_fails() -> TestResult {
     init().await;
+
+    #[derive(Model, Serialize, Deserialize, Debug)]
+    #[db("test")]
+    #[collection("validate_non_empty_fail")]
+    struct StringValidation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        _id: Option<ObjectId>,
+
+        #[validate(non_empty)]
+        value: Option<String>,
+    }
+
     StringValidation::clear().await?;
 
-    let doc = StringValidation::default()
-        .value("   ".to_string()); // ❌ empty string after trim
-
+    let doc = StringValidation::default().value("   ".to_string());
     let result = doc.save().await;
     assert!(result.is_err());
     assert!(format!("{:?}", result).contains("must be non-empty"));


### PR DESCRIPTION
In this fix, each test is given its own model struct in order to prevent multi-threading to clear the collection before the tests end.